### PR TITLE
Serialize mongoose object to index populated fields references

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -95,6 +95,10 @@ module.exports.serialize = function serialize(document, mapping) {
 
   if (document && typeof document === 'object') {
     name = document.constructor.name;
+    if (name === 'model') {
+      return document.id;
+    }
+
     if (name === 'ObjectID') {
       return document.toString();
     }


### PR DESCRIPTION
Hi, I noticed that when trying to index a document with an es_indexed of type ObjectId, and that document has that reference populated, it isn't serializing it correctly. This is my attemp to do that.