### PR TITLE
Adds ability to use mongoose query for synchronize

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,12 +331,22 @@ Book
   });
 ```
 
-`esSynchronise` use same parameters as [find](http://mongoosejs.com/docs/api.html#model_Model.find) method.
+`esSynchronise` use same parameters as [find](http://mongoosejs.com/docs/api.html#model_Model.find) method or alternativaly you can pass a mongoose query instance in order to use any specific methods like `.populate()`.
 It allows to synchronize a subset of documents, modifying the default projection...
 
 ```javascript
 Book
   .esSynchronize({author: 'Arthur C. Clarke'}, '+resume')
+  .then(function () {
+    console.log('end.');
+  });
+```
+
+```javascript
+// using a mongoose query instance, populating the author `ref`
+const query = Book.find({author: 'Arthur C. Clarke'}).populate('author')
+Book
+  .esSynchronize(query, '+resume')
   .then(function () {
     console.log('end.');
   });

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Book
   });
 ```
 
-`esSynchronise` use same parameters as [find](http://mongoosejs.com/docs/api.html#model_Model.find) method or alternativaly you can pass a mongoose query instance in order to use any specific methods like `.populate()`.
+`esSynchronise` use same parameters as [find](http://mongoosejs.com/docs/api.html#model_Model.find) method or alternatively you can pass a mongoose query instance in order to use any specific methods like `.populate()`.
 It allows to synchronize a subset of documents, modifying the default projection...
 
 ```javascript

--- a/lib/index.js
+++ b/lib/index.js
@@ -329,11 +329,19 @@ function synchronize(conditions, projection, options, callback) {
     const batch = esOptions.bulk && esOptions.bulk.batch
       ? esOptions.bulk.batch
       : 50;
-    const stream = model
-      .find(conditions || {}, projection, options)
-      .lean()
-      .batchSize(batch)
-      .stream();
+    let stream;
+    if (conditions instanceof mongoose.Query) {
+      stream = conditions
+        .lean()
+        .batchSize(batch)
+        .stream();
+    } else {
+      stream = model
+        .find(conditions || {}, projection, options)
+        .lean()
+        .batchSize(batch)
+        .stream();
+    }
     const bulker = esOptions.bulker || new Bulker(esOptions.client);
     let streamClosed = false;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -331,10 +331,7 @@ function synchronize(conditions, projection, options, callback) {
       : 50;
     let stream;
     if (conditions instanceof mongoose.Query) {
-      stream = conditions
-        .lean()
-        .batchSize(batch)
-        .stream();
+      stream = conditions.lean().batchSize(batch).stream();
     } else {
       stream = model
         .find(conditions || {}, projection, options)

--- a/lib/index.js
+++ b/lib/index.js
@@ -326,12 +326,14 @@ function synchronize(conditions, projection, options, callback) {
   const model = this;
   return utils.run(callback, (resolve, reject) => {
     const esOptions = model.esOptions();
-    const batch = esOptions.bulk && esOptions.bulk.batch
-      ? esOptions.bulk.batch
-      : 50;
+    const batch =
+      esOptions.bulk && esOptions.bulk.batch ? esOptions.bulk.batch : 50;
     let stream;
     if (conditions instanceof mongoose.Query) {
-      stream = conditions.lean().batchSize(batch).stream();
+      stream = conditions
+        .lean()
+        .batchSize(batch)
+        .stream();
     } else {
       stream = model
         .find(conditions || {}, projection, options)


### PR DESCRIPTION
Hi, i needed to include populated models data inside ES index in order to have data denormalised so in to achieve it directly from the `esSynchronise` I added the ability to use a Mongoose Query instead of adding more params to the method.

An example:
```
const query = User.find({ id: '....' }).populate('car', 'brand year').populate('city', 'name location')
User.esSynchronize(query).then(.....)
```

What do you think? I may need to add testing and proper info to the docs if you agree about this approach.

Thanks! 