### PR TITLE
Mongoose 5.0.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,8 @@
     "prefer-rest-params": 0,
     "no-param-reassign": 0,
     "strict": 0,
-    "prefer-spread": 0
+    "prefer-spread": 0,
+    "prefer-destructuring": 0
   },
   "env": {
     "mocha": true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ cache:
     - node_modules
 
 node_js:
-  - "7"
+  - "9"
+  - "8"
   - "6"
   - "4"
 

--- a/lib/bulker.js
+++ b/lib/bulker.js
@@ -39,12 +39,9 @@ function Bulker(client, options) {
 
   self.delay = function() {
     clearTimeout(timeout);
-    timeout = setTimeout(
-      () => {
-        self.flush();
-      },
-      delay
-    );
+    timeout = setTimeout(() => {
+      self.flush();
+    }, delay);
   };
 
   self.filled = function() {

--- a/lib/bulker.js
+++ b/lib/bulker.js
@@ -18,6 +18,7 @@ function Bulker(client, options) {
   options = options || {}; // eslint-disable-line
 
   let timeout;
+  let flushing = false;
   const self = this;
   const delay = options.delay || 1000;
   const size = options.size || 1000;
@@ -48,11 +49,17 @@ function Bulker(client, options) {
     return !!buffer.length;
   };
 
+  self.isFlushing = function() {
+    return flushing;
+  };
+
   self.flush = function() {
     const len = buffer.length;
     clearTimeout(timeout);
     if (len) {
+      flushing = true;
       client.bulk({ body: buffer }, err => {
+        flushing = false;
         if (err) {
           self.emit('error', err);
         } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -393,7 +393,7 @@ function synchronize(conditions, projection, options, callback) {
       streamClosed = true;
       if (bulker.filled()) {
         bulker.flush();
-      } else {
+      } else if (!bulker.isFlushing()) {
         finalize();
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -304,7 +304,7 @@ function search(query, options, callback) {
  * Synchronize the collection with ElasticSearch
  * static function
  * @param {Object} [conditions]
- * @param {String} [projection]
+ * @param {String|Object} [projection]
  * @param {Object} [options]
  * @param {Function} [callback]
  * @returns {Promise|undefined}

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,44 +95,44 @@ function createMapping(settings, callback) {
     const mapping = {};
     mapping[esOptions.type] = esOptions.mapping;
 
-    esOptions.client.indices.exists({ index: esOptions.index }, (
-      err,
-      exists
-    ) => {
-      if (err) {
-        return reject(err);
-      }
-      if (exists) {
-        return esOptions.client.indices.putMapping(
-          {
-            index: esOptions.index,
-            type: esOptions.type,
-            body: mapping,
-          },
-          (err, result) => err ? reject(err) : resolve(result)
-        );
-      }
-      return esOptions.client.indices.create(
-        {
-          index: esOptions.index,
-          body: settings,
-        },
-        err => {
-          if (err) {
-            reject(err);
-            return;
-          }
-          esOptions.client.indices.putMapping(
+    esOptions.client.indices.exists(
+      { index: esOptions.index },
+      (err, exists) => {
+        if (err) {
+          return reject(err);
+        }
+        if (exists) {
+          return esOptions.client.indices.putMapping(
             {
               index: esOptions.index,
               type: esOptions.type,
               body: mapping,
             },
-            (err, result) => err ? reject(err) : resolve(result)
+            (err, result) => (err ? reject(err) : resolve(result))
           );
         }
-      );
-    });
+        return esOptions.client.indices.create(
+          {
+            index: esOptions.index,
+            body: settings,
+          },
+          err => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            esOptions.client.indices.putMapping(
+              {
+                index: esOptions.index,
+                type: esOptions.type,
+                body: mapping,
+              },
+              (err, result) => (err ? reject(err) : resolve(result))
+            );
+          }
+        );
+      }
+    );
   });
 }
 
@@ -152,15 +152,16 @@ function refresh(options, callback) {
   const self = this;
   return utils.run(callback, (resolve, reject) => {
     const esOptions = self.esOptions();
-    const refreshDelay = options.refreshDelay === false
-      ? 0
-      : options.refreshDelay || esOptions.refreshDelay;
+    const refreshDelay =
+      options.refreshDelay === false
+        ? 0
+        : options.refreshDelay || esOptions.refreshDelay;
     esOptions.client.indices.refresh(
       {
         index: esOptions.index,
       },
       (err, result) => {
-        setTimeout(() => err ? reject(err) : resolve(result), refreshDelay);
+        setTimeout(() => (err ? reject(err) : resolve(result)), refreshDelay);
       }
     );
   });
@@ -184,9 +185,10 @@ function count(query, options, callback) {
   const self = this;
   return utils.run(callback, (resolve, reject) => {
     const esOptions = self.esOptions();
-    const countOnly = options.countOnly === false
-      ? false
-      : options.countOnly || esOptions.countOnly;
+    const countOnly =
+      options.countOnly === false
+        ? false
+        : options.countOnly || esOptions.countOnly;
     const params = {
       index: esOptions.index,
       type: esOptions.type,
@@ -224,12 +226,10 @@ function search(query, options, callback) {
   const self = this;
   return utils.run(callback, (resolve, reject) => {
     const esOptions = self.esOptions();
-    const hydrate = options.hydrate === false
-      ? false
-      : options.hydrate || esOptions.hydrate;
-    const idsOnly = options.idsOnly === false
-      ? false
-      : options.idsOnly || esOptions.idsOnly;
+    const hydrate =
+      options.hydrate === false ? false : options.hydrate || esOptions.hydrate;
+    const idsOnly =
+      options.idsOnly === false ? false : options.idsOnly || esOptions.idsOnly;
 
     const params = {
       index: esOptions.index,
@@ -258,7 +258,7 @@ function search(query, options, callback) {
       const isObjectId = utils.getType(self.schema.paths._id) === 'objectid';
 
       const ids = result.hits.hits.map(
-        hit => isObjectId ? mongoose.Types.ObjectId(hit._id) : hit._id
+        hit => (isObjectId ? mongoose.Types.ObjectId(hit._id) : hit._id)
       );
 
       if (idsOnly) {
@@ -326,9 +326,8 @@ function synchronize(conditions, projection, options, callback) {
   const model = this;
   return utils.run(callback, (resolve, reject) => {
     const esOptions = model.esOptions();
-    const batch = esOptions.bulk && esOptions.bulk.batch
-      ? esOptions.bulk.batch
-      : 50;
+    const batch =
+      esOptions.bulk && esOptions.bulk.batch ? esOptions.bulk.batch : 50;
     const stream = model
       .find(conditions || {}, projection, options)
       .lean()
@@ -342,7 +341,7 @@ function synchronize(conditions, projection, options, callback) {
       bulker.removeListener('sent', onSent);
       esOptions.client.indices.refresh(
         { index: esOptions.index },
-        (err, result) => err ? reject(err) : resolve(result)
+        (err, result) => (err ? reject(err) : resolve(result))
       );
     }
 
@@ -420,7 +419,8 @@ function indexDoc(update, callback) {
     if (update && update.unset) {
       (typeof update.unset === 'string'
         ? [update.unset]
-        : update.unset).forEach(field => {
+        : update.unset
+      ).forEach(field => {
         body[field] = null;
       });
     }
@@ -492,7 +492,7 @@ function unsetFields(fields, callback) {
         id: self._id.toString(),
         body,
       },
-      (err, result) => err ? reject(err) : resolve(result)
+      (err, result) => (err ? reject(err) : resolve(result))
     );
   });
 }

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -31,7 +31,7 @@ function generate(schema, version) {
     if (
       explicit &&
       isEmbedded(type) &&
-      !({}).hasOwnProperty.call(options, 'es_indexed')
+      !{}.hasOwnProperty.call(options, 'es_indexed')
     ) {
       options.es_indexed = hasExplicit(path.schema, typeKey);
     }
@@ -64,7 +64,7 @@ function generate(schema, version) {
       current.type = 'object';
       current.properties = generateESTypeMapping(options.es_type);
     } else {
-      if (!({}).hasOwnProperty.call(options, 'es_value') || !options.es_type) {
+      if (!{}.hasOwnProperty.call(options, 'es_value') || !options.es_type) {
         if (isEmbedded(type)) {
           current.type = 'object';
           current.properties = generate(path.schema, version);
@@ -82,12 +82,13 @@ function generate(schema, version) {
       });
     }
 
-    if (({}).hasOwnProperty.call(options, 'es_value')) {
-      current.value = typeof options.es_value === 'function'
-        ? options.es_value
-        : (function() {
-            return options.es_value;
-          });
+    if ({}.hasOwnProperty.call(options, 'es_value')) {
+      current.value =
+        typeof options.es_value === 'function'
+          ? options.es_value
+          : function() {
+              return options.es_value;
+            };
     }
   });
 
@@ -112,7 +113,8 @@ function getTypeKey(schema) {
 }
 
 function hasExplicit(schema, typeKey) {
-  return schema && schema.paths ? Object.keys(schema.paths).some(name => {
+  return schema && schema.paths
+    ? Object.keys(schema.paths).some(name => {
         if (name === '_id') {
           return; // eslint-disable-line
         }
@@ -123,11 +125,9 @@ function hasExplicit(schema, typeKey) {
             return true;
           }
         }
-        return ({}).hasOwnProperty.call(
-          getOptions(path, typeKey),
-          'es_indexed'
-        );
-      }) : false;
+        return {}.hasOwnProperty.call(getOptions(path, typeKey), 'es_indexed');
+      })
+    : false;
 }
 
 function getOptions(path, typeKey) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 
 const mongoose = require('mongoose');
 
-const _Promise = mongoose.Promise.ES6;
+const _Promise = mongoose.Promise.ES6 || global.Promise;
 
 module.exports = {};
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,7 +65,7 @@ module.exports.getUndefineds = function getUndefineds(document, mapping) {
   let field;
   const result = [];
   for (field in mapping.properties) {
-    if (({}).hasOwnProperty.call(mapping.properties, field)) {
+    if ({}.hasOwnProperty.call(mapping.properties, field)) {
       if (document[field] === undefined && document.isModified(field)) {
         result.push(field);
       }
@@ -92,14 +92,15 @@ module.exports.serialize = function serialize(document, mapping, main) {
       let value;
       const property = mappingData.properties[field];
       try {
-        if (({}).hasOwnProperty.call(property, 'value')) {
-          value = typeof property.value === 'function'
-            ? property.value(object[field], {
-                document: main,
-                container: object,
-                field,
-              })
-            : property.value;
+        if ({}.hasOwnProperty.call(property, 'value')) {
+          value =
+            typeof property.value === 'function'
+              ? property.value(object[field], {
+                  document: main,
+                  container: object,
+                  field,
+                })
+              : property.value;
         } else if (object[field] !== undefined) {
           value = serialize.call(object, object[field], property, main);
         }
@@ -152,5 +153,6 @@ module.exports.serialize = function serialize(document, mapping, main) {
 module.exports.getType = function getType(path) {
   return (path.caster && path.caster.instance
     ? path.caster.instance
-    : path.instance).toLowerCase();
+    : path.instance
+  ).toLowerCase();
 };

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
   "author": "Jean-Baptiste Demonte <jbdemonte@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "elasticsearch": "^12.1.3",
+    "elasticsearch": "^12.1.3 || ^13.0.0 || ^14.0.0",
     "mongoose": "^4.2.2"
   },
   "devDependencies": {
     "bluebird": "^3.5.1",
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
-    "elasticsearch": "^12.1.3",
+    "elasticsearch": "^14.1.0",
     "eslint": "^4.17.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-prettier": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -39,20 +39,20 @@
     "mongoose": "^4.2.2"
   },
   "devDependencies": {
-    "bluebird": "^3.4.6",
-    "chai": "^3.5.0",
-    "coveralls": "^2.11.14",
+    "bluebird": "^3.5.1",
+    "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
     "elasticsearch": "^12.1.3",
-    "eslint": "^3.16.1",
-    "eslint-config-airbnb-base": "^11.1.0",
-    "eslint-config-prettier": "^1.4.0",
+    "eslint": "^4.17.0",
+    "eslint-config-airbnb-base": "^12.1.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-chai-expect": "^1.1.1",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-prettier": "^2.0.1",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-prettier": "^2.6.0",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0",
+    "mocha": "^5.0.0",
     "mongoose": "^4.2.2",
-    "prettier": "^0.19.0",
+    "prettier": "^1.10.2",
     "shortid": "^2.2.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "peerDependencies": {
     "elasticsearch": "^12.1.3 || ^13.0.0 || ^14.0.0",
-    "mongoose": "^4.2.2"
+    "mongoose": "^4.9.0 || ^5.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
@@ -50,7 +50,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.0.0",
-    "mongoose": "^4.2.2",
+    "mongoose": "5.0.3",
     "prettier": "^1.10.2",
     "shortid": "^2.2.8"
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "mongoose": "^4.2.2"
   },
   "devDependencies": {
-    "bluebird": "^3.5.1",
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
     "elasticsearch": "^14.1.0",

--- a/test/es2/countOnly.js
+++ b/test/es2/countOnly.js
@@ -43,28 +43,26 @@ describe('countOnly', () => {
 
   it('should return count', () => {
     return UserModel.esCount(
-        {
-          query: { match_all: {} },
-          filter: { range: { age: { gte: 35 } } },
-        },
-        { countOnly: true }
-      )
-      .then(count => {
-        expect(count).to.eql(2);
-      });
+      {
+        query: { match_all: {} },
+        filter: { range: { age: { gte: 35 } } },
+      },
+      { countOnly: true }
+    ).then(count => {
+      expect(count).to.eql(2);
+    });
   });
 
   it('should return 0', () => {
     return UserModel.esCount(
-        {
-          query: { match_all: {} },
-          filter: { range: { age: { gte: 100 } } },
-        },
-        { countOnly: true }
-      )
-      .then(count => {
-        expect(count).to.eql(0);
-      });
+      {
+        query: { match_all: {} },
+        filter: { range: { age: { gte: 100 } } },
+      },
+      { countOnly: true }
+    ).then(count => {
+      expect(count).to.eql(0);
+    });
   });
 
   it('should return count when defined in plugin', () => {
@@ -80,12 +78,11 @@ describe('countOnly', () => {
     const UserModelCountOnly = mongoose.model('User', UserSchema);
 
     return UserModelCountOnly.esCount({
-        query: { match_all: {} },
-        filter: { range: { age: { gte: 35 } } },
-      })
-      .then(count => {
-        expect(count).to.eql(2);
-      });
+      query: { match_all: {} },
+      filter: { range: { age: { gte: 35 } } },
+    }).then(count => {
+      expect(count).to.eql(2);
+    });
   });
 
   it('should overwrite defined in plugin value', () => {
@@ -100,14 +97,13 @@ describe('countOnly', () => {
     const UserModelCountOnly = mongoose.model('User', UserSchema);
 
     return UserModelCountOnly.esCount(
-        {
-          query: { match_all: {} },
-          filter: { range: { age: { gte: 35 } } },
-        },
-        { countOnly: false }
-      )
-      .then(result => {
-        expect(result.count).to.eql(2);
-      });
+      {
+        query: { match_all: {} },
+        filter: { range: { age: { gte: 35 } } },
+      },
+      { countOnly: false }
+    ).then(result => {
+      expect(result.count).to.eql(2);
+    });
   });
 });

--- a/test/es2/customIds.js
+++ b/test/es2/customIds.js
@@ -52,25 +52,7 @@ describe('custom ids', () => {
 
   it('should return ids', () => {
     return UserModel.esSearch(
-        {
-          query: {
-            bool: {
-              must: { match_all: {} },
-              filter: { range: { age: { gte: 35 } } },
-            },
-          },
-          sort: [{ age: { order: 'desc' } }],
-        },
-        { idsOnly: true }
-      )
-      .then(ids => {
-        expect(ids.length).to.eql(2);
-        expect(ids).to.eql([bob._id, john._id]);
-      });
-  });
-
-  it('should return people', () => {
-    return UserModel.esSearch({
+      {
         query: {
           bool: {
             must: { match_all: {} },
@@ -78,11 +60,27 @@ describe('custom ids', () => {
           },
         },
         sort: [{ age: { order: 'desc' } }],
-      })
-      .then(result => {
-        expect(result.hits.total).to.eql(2);
-        expect(result.hits.hits[0]._source).to.eql({ name: 'Bob', age: 36 });
-        expect(result.hits.hits[1]._source).to.eql({ name: 'John', age: 35 });
-      });
+      },
+      { idsOnly: true }
+    ).then(ids => {
+      expect(ids.length).to.eql(2);
+      expect(ids).to.eql([bob._id, john._id]);
+    });
+  });
+
+  it('should return people', () => {
+    return UserModel.esSearch({
+      query: {
+        bool: {
+          must: { match_all: {} },
+          filter: { range: { age: { gte: 35 } } },
+        },
+      },
+      sort: [{ age: { order: 'desc' } }],
+    }).then(result => {
+      expect(result.hits.total).to.eql(2);
+      expect(result.hits.hits[0]._source).to.eql({ name: 'Bob', age: 36 });
+      expect(result.hits.hits[1]._source).to.eql({ name: 'John', age: 35 });
+    });
   });
 });

--- a/test/es2/document-hook.js
+++ b/test/es2/document-hook.js
@@ -163,13 +163,10 @@ describe('document-hook', () => {
             }
             count++;
             if (count === 3) {
-              setTimeout(
-                () => {
-                  // delay to check if more than 3 are received
-                  resolve();
-                },
-                500
-              );
+              setTimeout(() => {
+                // delay to check if more than 3 are received
+                resolve();
+              }, 500);
             } else if (count > 3) {
               reject(new Error('more than 3 event were emitted'));
             }
@@ -189,13 +186,10 @@ describe('document-hook', () => {
             }
             count++;
             if (count === 3) {
-              setTimeout(
-                () => {
-                  // delay to check if more than 3 are received
-                  resolve();
-                },
-                500
-              );
+              setTimeout(() => {
+                // delay to check if more than 3 are received
+                resolve();
+              }, 500);
             } else if (count > 3) {
               reject(new Error('more than 3 event were emitted'));
             }

--- a/test/es2/esCount.js
+++ b/test/es2/esCount.js
@@ -82,12 +82,11 @@ describe('esCount', () => {
 
   it('should handle a full query', () => {
     return UserModel.esCount({
-        query: { match_all: {} },
-        filter: { range: { age: { lt: 35 } } },
-      })
-      .then(result => {
-        expect(result.count).to.eql(1);
-      });
+      query: { match_all: {} },
+      filter: { range: { age: { lt: 35 } } },
+    }).then(result => {
+      expect(result.count).to.eql(1);
+    });
   });
 
   it('should handle a short query', () => {

--- a/test/es2/esSearch.js
+++ b/test/es2/esSearch.js
@@ -110,15 +110,14 @@ describe('esSearch', () => {
 
   it('should handle a full query', () => {
     return UserModel.esSearch({
-        query: { match_all: {} },
-        filter: { range: { age: { lt: 35 } } },
-      })
-      .then(result => {
-        expect(result.hits.total).to.eql(1);
-        const hit = result.hits.hits[0];
-        expect(hit._id).to.eql(users.jane._id.toString());
-        expect(hit._source).to.eql({ name: 'Jane', age: 34 });
-      });
+      query: { match_all: {} },
+      filter: { range: { age: { lt: 35 } } },
+    }).then(result => {
+      expect(result.hits.total).to.eql(1);
+      const hit = result.hits.hits[0];
+      expect(hit._id).to.eql(users.jane._id.toString());
+      expect(hit._source).to.eql({ name: 'Jane', age: 34 });
+    });
   });
 
   it('should handle a short query', () => {

--- a/test/es2/esSynchronise.js
+++ b/test/es2/esSynchronise.js
@@ -260,7 +260,7 @@ describe('esSynchronise', () => {
           docSent++;
         });
 
-        return UserPluginModel.esSynchronize({}, '+age').then(() => {
+        return UserPluginModel.esSynchronize({}, { name: 1 }).then(() => {
           expect(error).to.be.equal(0);
           expect(docSent).to.be.equal(users.length);
           expect(sent).to.be.equal(Math.ceil(2 * users.length / bulkSize));
@@ -276,7 +276,7 @@ describe('esSynchronise', () => {
                   expect(result.hits.total).to.eql(1);
                   const hit = result.hits.hits[0];
                   expect(hit._source.name).to.be.equal(user.name);
-                  expect(hit._source.age).to.be.equal(user.age);
+                  expect(hit._source.age).to.be.equal(undefined);
                   resolve();
                 })
                 .catch(err => {
@@ -554,7 +554,7 @@ describe('esSynchronise', () => {
         });
 
         return new utils.Promise((resolve, reject) => {
-          UserPluginModel.esSynchronize({}, '+age', err => {
+          UserPluginModel.esSynchronize({}, 'age', err => {
             if (err) {
               reject(err);
               return;
@@ -574,7 +574,7 @@ describe('esSynchronise', () => {
                 .then(result => {
                   expect(result.hits.total).to.eql(1);
                   const hit = result.hits.hits[0];
-                  expect(hit._source.name).to.be.equal(user.name);
+                  expect(hit._source.name).to.be.equal(undefined);
                   expect(hit._source.age).to.be.equal(user.age);
                   resolve();
                 })

--- a/test/es2/hydratation.js
+++ b/test/es2/hydratation.js
@@ -103,98 +103,95 @@ describe('hydratation', () => {
 
   it('should hydrate', () => {
     return UserModel.esSearch(
-        {
-          query: { match_all: {} },
-          sort: [{ age: { order: 'desc' } }],
-          filter: { range: { age: { gte: 35 } } },
-        },
-        { hydrate: true }
-      )
-      .then(result => {
-        let hit;
-        expect(result.hits.total).to.eql(2);
+      {
+        query: { match_all: {} },
+        sort: [{ age: { order: 'desc' } }],
+        filter: { range: { age: { gte: 35 } } },
+      },
+      { hydrate: true }
+    ).then(result => {
+      let hit;
+      expect(result.hits.total).to.eql(2);
 
-        hit = result.hits.hits[0];
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(bob._id.toString());
-        expect(hit.doc.name).to.eql(bob.name);
-        expect(hit.doc.age).to.eql(bob.age);
+      hit = result.hits.hits[0];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(bob._id.toString());
+      expect(hit.doc.name).to.eql(bob.name);
+      expect(hit.doc.age).to.eql(bob.age);
 
-        hit = result.hits.hits[1];
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(john._id.toString());
-        expect(hit.doc.name).to.eql(john.name);
-        expect(hit.doc.age).to.eql(john.age);
-      });
+      hit = result.hits.hits[1];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(john._id.toString());
+      expect(hit.doc.name).to.eql(john.name);
+      expect(hit.doc.age).to.eql(john.age);
+    });
   });
 
   it('should hydrate returning only models', () => {
     return UserModel.esSearch(
-        {
-          query: { match_all: {} },
-          sort: [{ age: { order: 'desc' } }],
-          filter: { range: { age: { gte: 35 } } },
-        },
-        { hydrate: { docsOnly: true } }
-      )
-      .then(users => {
-        let user;
-        expect(users.length).to.eql(2);
+      {
+        query: { match_all: {} },
+        sort: [{ age: { order: 'desc' } }],
+        filter: { range: { age: { gte: 35 } } },
+      },
+      { hydrate: { docsOnly: true } }
+    ).then(users => {
+      let user;
+      expect(users.length).to.eql(2);
 
-        user = users[0];
-        expect(user._id.toString()).to.eql(bob._id.toString());
-        expect(user.name).to.eql(bob.name);
-        expect(user.age).to.eql(bob.age);
+      user = users[0];
+      expect(user._id.toString()).to.eql(bob._id.toString());
+      expect(user.name).to.eql(bob.name);
+      expect(user.age).to.eql(bob.age);
 
-        user = users[1];
-        expect(user._id.toString()).to.eql(john._id.toString());
-        expect(user.name).to.eql(john.name);
-        expect(user.age).to.eql(john.age);
-      });
+      user = users[1];
+      expect(user._id.toString()).to.eql(john._id.toString());
+      expect(user.name).to.eql(john.name);
+      expect(user.age).to.eql(john.age);
+    });
   });
 
   it('should return an empty array when hydrating only models on 0 hit', () => {
     return UserModel.esSearch(
-        {
-          query: { match_all: {} },
-          sort: [{ age: { order: 'desc' } }],
-          filter: { range: { age: { gte: 100 } } },
-        },
-        { hydrate: { docsOnly: true } }
-      )
-      .then(users => {
-        expect(users).to.eql([]);
-      });
+      {
+        query: { match_all: {} },
+        sort: [{ age: { order: 'desc' } }],
+        filter: { range: { age: { gte: 100 } } },
+      },
+      { hydrate: { docsOnly: true } }
+    ).then(users => {
+      expect(users).to.eql([]);
+    });
   });
 
   it('should hydrate using projection', () => {
-    return UserModel.esSearch('name:jane', { hydrate: { select: 'name' } })
-      .then(result => {
-        expect(result.hits.total).to.eql(1);
-        const hit = result.hits.hits[0];
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(jane._id.toString());
-        expect(hit.doc.name).to.eql(jane.name);
-        expect(hit.doc.age).to.be.undefined;
-      });
+    return UserModel.esSearch('name:jane', {
+      hydrate: { select: 'name' },
+    }).then(result => {
+      expect(result.hits.total).to.eql(1);
+      const hit = result.hits.hits[0];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(jane._id.toString());
+      expect(hit.doc.name).to.eql(jane.name);
+      expect(hit.doc.age).to.be.undefined;
+    });
   });
 
   it('should hydrate using options', () => {
     return UserModel.esSearch('name:jane', {
-        hydrate: { options: { lean: true } },
-      })
-      .then(result => {
-        expect(result.hits.total).to.eql(1);
-        const hit = result.hits.hits[0];
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).not.to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(jane._id.toString());
-        expect(hit.doc.name).to.eql(jane.name);
-        expect(hit.doc.age).to.eql(jane.age);
-      });
+      hydrate: { options: { lean: true } },
+    }).then(result => {
+      expect(result.hits.total).to.eql(1);
+      const hit = result.hits.hits[0];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).not.to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(jane._id.toString());
+      expect(hit.doc.name).to.eql(jane.name);
+      expect(hit.doc.age).to.eql(jane.age);
+    });
   });
 
   it('should hydrate when defined in plugin', () => {
@@ -233,24 +230,23 @@ describe('hydratation', () => {
     const UserModelHydrate = mongoose.model('User', UserSchema);
 
     return UserModelHydrate.esSearch({
-        query: { match_all: {} },
-        sort: [{ age: { order: 'desc' } }],
-        filter: { range: { age: { gte: 35 } } },
-      })
-      .then(users => {
-        let user;
-        expect(users.length).to.eql(2);
+      query: { match_all: {} },
+      sort: [{ age: { order: 'desc' } }],
+      filter: { range: { age: { gte: 35 } } },
+    }).then(users => {
+      let user;
+      expect(users.length).to.eql(2);
 
-        user = users[0];
-        expect(user._id.toString()).to.eql(bob._id.toString());
-        expect(user.name).to.eql(bob.name);
-        expect(user.age).to.eql(bob.age);
+      user = users[0];
+      expect(user._id.toString()).to.eql(bob._id.toString());
+      expect(user.name).to.eql(bob.name);
+      expect(user.age).to.eql(bob.age);
 
-        user = users[1];
-        expect(user._id.toString()).to.eql(john._id.toString());
-        expect(user.name).to.eql(john.name);
-        expect(user.age).to.eql(john.age);
-      });
+      user = users[1];
+      expect(user._id.toString()).to.eql(john._id.toString());
+      expect(user.name).to.eql(john.name);
+      expect(user.age).to.eql(john.age);
+    });
   });
 
   it('should hydrate when defined in plugin using projection', () => {
@@ -352,111 +348,106 @@ describe('hydratation', () => {
 
   it('should hydrate with a simple populate', () => {
     return UserModel.esSearch(
-        {
-          query: { match_all: {} },
-          sort: [{ age: { order: 'desc' } }],
-          filter: { range: { age: { gte: 35 } } },
-        },
-        {
-          hydrate: {
-            populate: {
-              path: 'city',
-            },
+      {
+        query: { match_all: {} },
+        sort: [{ age: { order: 'desc' } }],
+        filter: { range: { age: { gte: 35 } } },
+      },
+      {
+        hydrate: {
+          populate: {
+            path: 'city',
           },
-        }
-      )
-      .then(result => {
-        let hit;
-        expect(result.hits.total).to.eql(2);
+        },
+      }
+    ).then(result => {
+      let hit;
+      expect(result.hits.total).to.eql(2);
 
-        hit = result.hits.hits[0];
+      hit = result.hits.hits[0];
 
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(bob._id.toString());
-        expect(hit.doc.name).to.eql(bob.name);
-        expect(hit.doc.age).to.eql(bob.age);
-        expect(hit.doc.city._id.toString()).to.eql(city2._id.toString());
-        expect(hit.doc.city.name).to.eql(city2.name);
-        // book should not be populated
-        expect(hit.doc.books.length).to.eql(1);
-        expect(hit.doc.books[0].toJSON()).to.eql(book2._id.toString());
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(bob._id.toString());
+      expect(hit.doc.name).to.eql(bob.name);
+      expect(hit.doc.age).to.eql(bob.age);
+      expect(hit.doc.city._id.toString()).to.eql(city2._id.toString());
+      expect(hit.doc.city.name).to.eql(city2.name);
+      // book should not be populated
+      expect(hit.doc.books.length).to.eql(1);
+      expect(hit.doc.books[0].toJSON()).to.eql(book2._id.toString());
 
-        hit = result.hits.hits[1];
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(john._id.toString());
-        expect(hit.doc.name).to.eql(john.name);
-        expect(hit.doc.age).to.eql(john.age);
-        expect(hit.doc.city._id.toString()).to.eql(city1._id.toString());
-        expect(hit.doc.city.name).to.eql(city1.name);
-        // book should not be populated
-        expect(hit.doc.books.length).to.eql(2);
-        expect(hit.doc.books[0].toJSON()).to.eql(book1._id.toString());
-        expect(hit.doc.books[1].toJSON()).to.eql(book2._id.toString());
-      });
+      hit = result.hits.hits[1];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(john._id.toString());
+      expect(hit.doc.name).to.eql(john.name);
+      expect(hit.doc.age).to.eql(john.age);
+      expect(hit.doc.city._id.toString()).to.eql(city1._id.toString());
+      expect(hit.doc.city.name).to.eql(city1.name);
+      // book should not be populated
+      expect(hit.doc.books.length).to.eql(2);
+      expect(hit.doc.books[0].toJSON()).to.eql(book1._id.toString());
+      expect(hit.doc.books[1].toJSON()).to.eql(book2._id.toString());
+    });
   });
 
-  it(
-    'should hydrate with an array of population including a complex one',
-    () => {
-      return UserModel.esSearch(
-          {
-            query: { match_all: {} },
-            sort: [{ age: { order: 'desc' } }],
-            filter: { range: { age: { gte: 35 } } },
-          },
-          {
-            hydrate: {
-              populate: [
-                {
-                  path: 'city',
-                },
-                {
-                  path: 'books',
-                  populate: {
-                    path: 'author',
-                  },
-                },
-              ],
+  it('should hydrate with an array of population including a complex one', () => {
+    return UserModel.esSearch(
+      {
+        query: { match_all: {} },
+        sort: [{ age: { order: 'desc' } }],
+        filter: { range: { age: { gte: 35 } } },
+      },
+      {
+        hydrate: {
+          populate: [
+            {
+              path: 'city',
             },
-          }
-        )
-        .then(result => {
-          let hit;
-          expect(result.hits.total).to.eql(2);
+            {
+              path: 'books',
+              populate: {
+                path: 'author',
+              },
+            },
+          ],
+        },
+      }
+    ).then(result => {
+      let hit;
+      expect(result.hits.total).to.eql(2);
 
-          hit = result.hits.hits[0];
+      hit = result.hits.hits[0];
 
-          expect(hit._source).to.be.undefined;
-          expect(hit.doc).to.be.an.instanceof(UserModel);
-          expect(hit.doc._id.toString()).to.eql(bob._id.toString());
-          expect(hit.doc.name).to.eql(bob.name);
-          expect(hit.doc.age).to.eql(bob.age);
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(bob._id.toString());
+      expect(hit.doc.name).to.eql(bob.name);
+      expect(hit.doc.age).to.eql(bob.age);
 
-          expect(hit.doc.city._id.toString()).to.eql(city2._id.toString());
-          expect(hit.doc.city.name).to.eql(city2.name);
+      expect(hit.doc.city._id.toString()).to.eql(city2._id.toString());
+      expect(hit.doc.city.name).to.eql(city2.name);
 
-          expect(hit.doc.books.length).to.eql(1);
-          expect(hit.doc.books[0].toJSON()).to.eql(book2.toJSON());
-          expect(hit.doc.books[0].author.toJSON()).to.eql(author2.toJSON());
+      expect(hit.doc.books.length).to.eql(1);
+      expect(hit.doc.books[0].toJSON()).to.eql(book2.toJSON());
+      expect(hit.doc.books[0].author.toJSON()).to.eql(author2.toJSON());
 
-          hit = result.hits.hits[1];
-          expect(hit._source).to.be.undefined;
-          expect(hit.doc).to.be.an.instanceof(UserModel);
-          expect(hit.doc._id.toString()).to.eql(john._id.toString());
-          expect(hit.doc.name).to.eql(john.name);
-          expect(hit.doc.age).to.eql(john.age);
+      hit = result.hits.hits[1];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(john._id.toString());
+      expect(hit.doc.name).to.eql(john.name);
+      expect(hit.doc.age).to.eql(john.age);
 
-          expect(hit.doc.city._id.toString()).to.eql(city1._id.toString());
-          expect(hit.doc.city.name).to.eql(city1.name);
+      expect(hit.doc.city._id.toString()).to.eql(city1._id.toString());
+      expect(hit.doc.city.name).to.eql(city1.name);
 
-          expect(hit.doc.books.length).to.eql(2);
-          expect(hit.doc.books[0].toJSON()).to.eql(book1.toJSON());
-          expect(hit.doc.books[0].author.toJSON()).to.eql(author1.toJSON());
-          expect(hit.doc.books[1].toJSON()).to.eql(book2.toJSON());
-          expect(hit.doc.books[1].author.toJSON()).to.eql(author2.toJSON());
-        });
-    }
-  );
+      expect(hit.doc.books.length).to.eql(2);
+      expect(hit.doc.books[0].toJSON()).to.eql(book1.toJSON());
+      expect(hit.doc.books[0].author.toJSON()).to.eql(author1.toJSON());
+      expect(hit.doc.books[1].toJSON()).to.eql(book2.toJSON());
+      expect(hit.doc.books[1].author.toJSON()).to.eql(author2.toJSON());
+    });
+  });
 });

--- a/test/es2/idsOnly.js
+++ b/test/es2/idsOnly.js
@@ -47,35 +47,33 @@ describe('idsOnly', () => {
 
   it('should return ids', () => {
     return UserModel.esSearch(
-        {
-          query: { match_all: {} },
-          sort: [{ age: { order: 'desc' } }],
-          filter: { range: { age: { gte: 35 } } },
-        },
-        { idsOnly: true }
-      )
-      .then(ids => {
-        expect(ids.length).to.eql(2);
-        const idstrings = ids.map(id => {
-          expect(id).to.be.an.instanceof(mongoose.Types.ObjectId);
-          return id.toString();
-        });
-        expect(idstrings).to.eql([bob._id.toString(), john._id.toString()]);
+      {
+        query: { match_all: {} },
+        sort: [{ age: { order: 'desc' } }],
+        filter: { range: { age: { gte: 35 } } },
+      },
+      { idsOnly: true }
+    ).then(ids => {
+      expect(ids.length).to.eql(2);
+      const idstrings = ids.map(id => {
+        expect(id).to.be.an.instanceof(mongoose.Types.ObjectId);
+        return id.toString();
       });
+      expect(idstrings).to.eql([bob._id.toString(), john._id.toString()]);
+    });
   });
 
   it('should an empty array', () => {
     return UserModel.esSearch(
-        {
-          query: { match_all: {} },
-          sort: [{ age: { order: 'desc' } }],
-          filter: { range: { age: { gte: 100 } } },
-        },
-        { idsOnly: true }
-      )
-      .then(ids => {
-        expect(ids).to.eql([]);
-      });
+      {
+        query: { match_all: {} },
+        sort: [{ age: { order: 'desc' } }],
+        filter: { range: { age: { gte: 100 } } },
+      },
+      { idsOnly: true }
+    ).then(ids => {
+      expect(ids).to.eql([]);
+    });
   });
 
   it('should return ids when defined in plugin', () => {
@@ -91,18 +89,17 @@ describe('idsOnly', () => {
     const UserModelIdsOnly = mongoose.model('User', UserSchema);
 
     return UserModelIdsOnly.esSearch({
-        query: { match_all: {} },
-        sort: [{ age: { order: 'desc' } }],
-        filter: { range: { age: { gte: 35 } } },
-      })
-      .then(ids => {
-        expect(ids.length).to.eql(2);
-        const idstrings = ids.map(id => {
-          expect(id).to.be.an.instanceof(mongoose.Types.ObjectId);
-          return id.toString();
-        });
-        expect(idstrings).to.eql([bob._id.toString(), john._id.toString()]);
+      query: { match_all: {} },
+      sort: [{ age: { order: 'desc' } }],
+      filter: { range: { age: { gte: 35 } } },
+    }).then(ids => {
+      expect(ids.length).to.eql(2);
+      const idstrings = ids.map(id => {
+        expect(id).to.be.an.instanceof(mongoose.Types.ObjectId);
+        return id.toString();
       });
+      expect(idstrings).to.eql([bob._id.toString(), john._id.toString()]);
+    });
   });
 
   it('should overwrite defined in plugin value', () => {
@@ -118,22 +115,21 @@ describe('idsOnly', () => {
     const UserModelIdsOnly = mongoose.model('User', UserSchema);
 
     return UserModelIdsOnly.esSearch(
-        {
-          query: { match_all: {} },
-          sort: [{ age: { order: 'desc' } }],
-          filter: { range: { age: { gte: 35 } } },
-        },
-        { idsOnly: false }
-      )
-      .then(result => {
-        expect(result.hits.total).to.eql(2);
-        let hit = result.hits.hits[0];
-        expect(hit._id).to.eql(bob._id.toString());
-        expect(hit._source).to.eql({ name: 'Bob', age: 36 });
+      {
+        query: { match_all: {} },
+        sort: [{ age: { order: 'desc' } }],
+        filter: { range: { age: { gte: 35 } } },
+      },
+      { idsOnly: false }
+    ).then(result => {
+      expect(result.hits.total).to.eql(2);
+      let hit = result.hits.hits[0];
+      expect(hit._id).to.eql(bob._id.toString());
+      expect(hit._source).to.eql({ name: 'Bob', age: 36 });
 
-        hit = result.hits.hits[1];
-        expect(hit._id).to.eql(john._id.toString());
-        expect(hit._source).to.eql({ name: 'John', age: 35 });
-      });
+      hit = result.hits.hits[1];
+      expect(hit._id).to.eql(john._id.toString());
+      expect(hit._source).to.eql({ name: 'John', age: 35 });
+    });
   });
 });

--- a/test/es2/model-mapping.js
+++ b/test/es2/model-mapping.js
@@ -439,56 +439,54 @@ describe('model-mapping', () => {
       })
       .then(() => {
         return GroupModel.esSearch({
-            query: {
-              nested: {
-                path: 'user',
-                query: {
-                  bool: {
-                    must: [
-                      { match: { 'user.first': 'Alice' } },
-                      { match: { 'user.last': 'Smith' } },
-                    ],
-                  },
+          query: {
+            nested: {
+              path: 'user',
+              query: {
+                bool: {
+                  must: [
+                    { match: { 'user.first': 'Alice' } },
+                    { match: { 'user.last': 'Smith' } },
+                  ],
                 },
               },
             },
-          })
-          .then(result => {
-            expect(result.hits.total).to.eql(0);
-          });
+          },
+        }).then(result => {
+          expect(result.hits.total).to.eql(0);
+        });
       })
       .then(() => {
         return GroupModel.esSearch({
-            query: {
-              nested: {
-                path: 'user',
-                query: {
-                  bool: {
-                    must: [
-                      { match: { 'user.first': 'Alice' } },
-                      { match: { 'user.last': 'White' } },
-                    ],
-                  },
+          query: {
+            nested: {
+              path: 'user',
+              query: {
+                bool: {
+                  must: [
+                    { match: { 'user.first': 'Alice' } },
+                    { match: { 'user.last': 'White' } },
+                  ],
                 },
               },
             },
-          })
-          .then(result => {
-            expect(result.hits.total).to.eql(1);
-            expect(result.hits.hits[0]._source).to.eql({
-              group: 'fans',
-              user: [
-                {
-                  first: 'John',
-                  last: 'Smith',
-                },
-                {
-                  first: 'Alice',
-                  last: 'White',
-                },
-              ],
-            });
+          },
+        }).then(result => {
+          expect(result.hits.total).to.eql(1);
+          expect(result.hits.hits[0]._source).to.eql({
+            group: 'fans',
+            user: [
+              {
+                first: 'John',
+                last: 'Smith',
+              },
+              {
+                first: 'Alice',
+                last: 'White',
+              },
+            ],
           });
+        });
       });
   });
 
@@ -591,7 +589,8 @@ describe('model-mapping', () => {
           properties.company.properties.city.properties.tags.properties
         ).to.have.all.keys('value');
         expect(
-          properties.company.properties.city.properties.tags.properties.value.type
+          properties.company.properties.city.properties.tags.properties.value
+            .type
         ).to.be.equal('string');
       })
       .then(() => {

--- a/test/es2/promise.js
+++ b/test/es2/promise.js
@@ -1,15 +1,14 @@
 'use strict';
 
-const bluebird = require('bluebird');
 const utils = require('../utils');
 const mongoose = require('mongoose');
 
 const plugin = require('../../').v2;
 
-describe('promise-bluebird', () => {
+describe('promise', () => {
   utils.setup();
 
-  it('should return bluebird promise', () => {
+  it('should return promise', () => {
     const UserSchema = new mongoose.Schema({
       name: String,
     });
@@ -18,6 +17,6 @@ describe('promise-bluebird', () => {
 
     const UserModel = mongoose.model('User', UserSchema);
     const promise = UserModel.esCreateMapping();
-    expect(promise).to.be.an.instanceof(bluebird);
+    expect(promise).to.be.an.instanceof(Promise);
   });
 });

--- a/test/es5/countOnly.js
+++ b/test/es5/countOnly.js
@@ -24,45 +24,46 @@ describe('countOnly', () => {
     return utils
       .deleteModelIndexes(UserModel)
       .then(() => UserModel.esCreateMapping())
-      .then(() => utils.Promise.all(
-        [john, jane, bob].map(
-          user => new utils.Promise(resolve => {
-            user.on('es-indexed', resolve);
-            user.save();
-          })
+      .then(() =>
+        utils.Promise.all(
+          [john, jane, bob].map(
+            user =>
+              new utils.Promise(resolve => {
+                user.on('es-indexed', resolve);
+                user.save();
+              })
+          )
         )
-      ))
+      )
       .then(() => UserModel.esRefresh());
   });
 
   it('should return count', () => {
     return UserModel.esCount(
-        {
-          bool: {
-            must: { match_all: {} },
-            filter: { range: { age: { gte: 35 } } },
-          },
+      {
+        bool: {
+          must: { match_all: {} },
+          filter: { range: { age: { gte: 35 } } },
         },
-        { countOnly: true }
-      )
-      .then(count => {
-        expect(count).to.eql(2);
-      });
+      },
+      { countOnly: true }
+    ).then(count => {
+      expect(count).to.eql(2);
+    });
   });
 
   it('should return 0', () => {
     return UserModel.esCount(
-        {
-          bool: {
-            must: { match_all: {} },
-            filter: { range: { age: { gte: 100 } } },
-          },
+      {
+        bool: {
+          must: { match_all: {} },
+          filter: { range: { age: { gte: 100 } } },
         },
-        { countOnly: true }
-      )
-      .then(count => {
-        expect(count).to.eql(0);
-      });
+      },
+      { countOnly: true }
+    ).then(count => {
+      expect(count).to.eql(0);
+    });
   });
 
   it('should return count when defined in plugin', () => {
@@ -78,14 +79,13 @@ describe('countOnly', () => {
     const UserModelCountOnly = mongoose.model('User', UserSchema);
 
     return UserModelCountOnly.esCount({
-        bool: {
-          must: { match_all: {} },
-          filter: { range: { age: { gte: 35 } } },
-        },
-      })
-      .then(count => {
-        expect(count).to.eql(2);
-      });
+      bool: {
+        must: { match_all: {} },
+        filter: { range: { age: { gte: 35 } } },
+      },
+    }).then(count => {
+      expect(count).to.eql(2);
+    });
   });
 
   it('should overwrite defined in plugin value', () => {
@@ -101,16 +101,15 @@ describe('countOnly', () => {
     const UserModelCountOnly = mongoose.model('User', UserSchema);
 
     return UserModelCountOnly.esCount(
-        {
-          bool: {
-            must: { match_all: {} },
-            filter: { range: { age: { gte: 35 } } },
-          },
+      {
+        bool: {
+          must: { match_all: {} },
+          filter: { range: { age: { gte: 35 } } },
         },
-        { countOnly: false }
-      )
-      .then(result => {
-        expect(result.count).to.eql(2);
-      });
+      },
+      { countOnly: false }
+    ).then(result => {
+      expect(result.count).to.eql(2);
+    });
   });
 });

--- a/test/es5/customIds.js
+++ b/test/es5/customIds.js
@@ -52,25 +52,7 @@ describe('custom ids', () => {
 
   it('should return ids', () => {
     return UserModel.esSearch(
-        {
-          query: {
-            bool: {
-              must: { match_all: {} },
-              filter: { range: { age: { gte: 35 } } },
-            },
-          },
-          sort: [{ age: { order: 'desc' } }],
-        },
-        { idsOnly: true }
-      )
-      .then(ids => {
-        expect(ids.length).to.eql(2);
-        expect(ids).to.eql([bob._id, john._id]);
-      });
-  });
-
-  it('should return people', () => {
-    return UserModel.esSearch({
+      {
         query: {
           bool: {
             must: { match_all: {} },
@@ -78,11 +60,27 @@ describe('custom ids', () => {
           },
         },
         sort: [{ age: { order: 'desc' } }],
-      })
-      .then(result => {
-        expect(result.hits.total).to.eql(2);
-        expect(result.hits.hits[0]._source).to.eql({ name: 'Bob', age: 36 });
-        expect(result.hits.hits[1]._source).to.eql({ name: 'John', age: 35 });
-      });
+      },
+      { idsOnly: true }
+    ).then(ids => {
+      expect(ids.length).to.eql(2);
+      expect(ids).to.eql([bob._id, john._id]);
+    });
+  });
+
+  it('should return people', () => {
+    return UserModel.esSearch({
+      query: {
+        bool: {
+          must: { match_all: {} },
+          filter: { range: { age: { gte: 35 } } },
+        },
+      },
+      sort: [{ age: { order: 'desc' } }],
+    }).then(result => {
+      expect(result.hits.total).to.eql(2);
+      expect(result.hits.hits[0]._source).to.eql({ name: 'Bob', age: 36 });
+      expect(result.hits.hits[1]._source).to.eql({ name: 'John', age: 35 });
+    });
   });
 });

--- a/test/es5/document-hook.js
+++ b/test/es5/document-hook.js
@@ -34,16 +34,17 @@ describe('document-hook', () => {
         user = new UserModel({ name: 'John', age: 35 });
       })
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          user.on('es-indexed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          user.save();
-        })
+        () =>
+          new utils.Promise((resolve, reject) => {
+            user.on('es-indexed', err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+            user.save();
+          })
       );
   });
 
@@ -63,67 +64,71 @@ describe('document-hook', () => {
       .deleteModelIndexes(UserModel)
       .then(() => UserModel.esCreateMapping())
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          user.on('es-indexed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          user.save();
-        })
+        () =>
+          new utils.Promise((resolve, reject) => {
+            user.on('es-indexed', err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+            user.save();
+          })
       )
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
 
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: user._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(true);
-              expect(resp._id).to.eql(user._id.toString());
-              expect(resp._source).to.eql({ name: 'John', age: 35 });
-              resolve();
-            }
-          );
-        })
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: user._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(true);
+                expect(resp._id).to.eql(user._id.toString());
+                expect(resp._source).to.eql({ name: 'John', age: 35 });
+                resolve();
+              }
+            );
+          })
       )
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          user.on('es-removed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          user.remove();
-        })
+        () =>
+          new utils.Promise((resolve, reject) => {
+            user.on('es-removed', err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+            user.remove();
+          })
       )
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
 
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: user._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(false);
-              expect(resp._id).to.eql(user._id.toString());
-              resolve();
-            }
-          );
-        })
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: user._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(false);
+                expect(resp._id).to.eql(user._id.toString());
+                resolve();
+              }
+            );
+          })
       );
   });
 
@@ -155,13 +160,10 @@ describe('document-hook', () => {
             }
             count++;
             if (count === 3) {
-              setTimeout(
-                () => {
-                  // delay to check if more than 3 are received
-                  resolve();
-                },
-                500
-              );
+              setTimeout(() => {
+                // delay to check if more than 3 are received
+                resolve();
+              }, 500);
             } else if (count > 3) {
               reject(new Error('more than 3 event were emitted'));
             }
@@ -181,13 +183,10 @@ describe('document-hook', () => {
             }
             count++;
             if (count === 3) {
-              setTimeout(
-                () => {
-                  // delay to check if more than 3 are received
-                  resolve();
-                },
-                500
-              );
+              setTimeout(() => {
+                // delay to check if more than 3 are received
+                resolve();
+              }, 500);
             } else if (count > 3) {
               reject(new Error('more than 3 event were emitted'));
             }
@@ -220,45 +219,48 @@ describe('document-hook', () => {
       .deleteModelIndexes(UserModel)
       .then(() => UserModel.esCreateMapping())
       .then(
-        () => new utils.Promise(resolve => {
-          john.on('es-filtered', () => {
-            resolve();
-          });
-          john.save();
-        })
+        () =>
+          new utils.Promise(resolve => {
+            john.on('es-filtered', () => {
+              resolve();
+            });
+            john.save();
+          })
       )
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          henry.on('es-indexed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          henry.save();
-        })
+        () =>
+          new utils.Promise((resolve, reject) => {
+            henry.on('es-indexed', err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+            henry.save();
+          })
       )
       .then(() => UserModel.esRefresh())
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.search(
-            {
-              index: options.index,
-              type: options.type,
-              body: { query: { match_all: {} } },
-            },
-            (err, resp) => {
-              expect(resp.hits.total).to.eql(1);
-              const hit = resp.hits.hits[0];
-              expect(hit._id).to.eql(henry._id.toString());
-              expect(hit._source).to.eql({ name: 'Henry', age: 85 });
-              resolve();
-            }
-          );
-        })
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.search(
+              {
+                index: options.index,
+                type: options.type,
+                body: { query: { match_all: {} } },
+              },
+              (err, resp) => {
+                expect(resp.hits.total).to.eql(1);
+                const hit = resp.hits.hits[0];
+                expect(hit._id).to.eql(henry._id.toString());
+                expect(hit._source).to.eql({ name: 'Henry', age: 85 });
+                resolve();
+              }
+            );
+          })
       );
   });
 
@@ -295,79 +297,83 @@ describe('document-hook', () => {
         });
       })
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          user.on('es-indexed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          user.save();
-        })
-      )
-      .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: user._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(true);
-              expect(resp._id).to.eql(user._id.toString());
-              expect(resp._source).to.eql({
-                name: 'John',
-                age: 35,
-                city: { name: 'Paris' },
-              });
-              resolve();
-            }
-          );
-        })
-      )
-      .then(
-        () => new utils.Promise((resolve, reject) => {
-          UserModel.findById(user._id).then(dbUser => {
-            dbUser.age = 36;
-            expect(dbUser.city).to.be.undefined; // because of select false
-
-            dbUser.on('es-indexed', err => {
+        () =>
+          new utils.Promise((resolve, reject) => {
+            user.on('es-indexed', err => {
               if (err) {
                 reject(err);
               } else {
                 resolve();
               }
             });
-            dbUser.save();
-          });
-        })
+            user.save();
+          })
       )
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: user._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(true);
-              expect(resp._id).to.eql(user._id.toString());
-              expect(resp._source).to.eql({
-                name: 'John',
-                age: 36,
-                city: { name: 'Paris' },
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: user._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(true);
+                expect(resp._id).to.eql(user._id.toString());
+                expect(resp._source).to.eql({
+                  name: 'John',
+                  age: 35,
+                  city: { name: 'Paris' },
+                });
+                resolve();
+              }
+            );
+          })
+      )
+      .then(
+        () =>
+          new utils.Promise((resolve, reject) => {
+            UserModel.findById(user._id).then(dbUser => {
+              dbUser.age = 36;
+              expect(dbUser.city).to.be.undefined; // because of select false
+
+              dbUser.on('es-indexed', err => {
+                if (err) {
+                  reject(err);
+                } else {
+                  resolve();
+                }
               });
-              resolve();
-            }
-          );
-        })
+              dbUser.save();
+            });
+          })
+      )
+      .then(
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: user._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(true);
+                expect(resp._id).to.eql(user._id.toString());
+                expect(resp._source).to.eql({
+                  name: 'John',
+                  age: 36,
+                  city: { name: 'Paris' },
+                });
+                resolve();
+              }
+            );
+          })
       );
   });
 
@@ -425,16 +431,17 @@ describe('document-hook', () => {
         });
       })
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          witness.on('es-indexed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          witness.save();
-        })
+        () =>
+          new utils.Promise((resolve, reject) => {
+            witness.on('es-indexed', err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+            witness.save();
+          })
       )
       .then(() => {
         UserModel = mongoose.model('User', UserSchema);
@@ -447,108 +454,113 @@ describe('document-hook', () => {
         });
       })
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          user.on('es-indexed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          user.save();
-        })
-      )
-      .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: user._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(true);
-              expect(resp._id).to.eql(user._id.toString());
-              expect(resp._source).to.eql({
-                name: 'John',
-                age: 35,
-                city: { name: 'Paris' },
-                job: { name: 'developer' },
-                skill: { name: 'math' },
-              });
-              resolve();
-            }
-          );
-        })
-      )
-      .then(
-        () => new utils.Promise((resolve, reject) => {
-          UserModel.findById(user._id, '+city +job +skill').then(dbUser => {
-            expect(dbUser.city).not.to.be.undefined; // because of select false
-            dbUser.city = undefined; // remove some fields
-            dbUser.job = undefined;
-            dbUser.age = 36;
-
-            dbUser.on('es-indexed', err => {
+        () =>
+          new utils.Promise((resolve, reject) => {
+            user.on('es-indexed', err => {
               if (err) {
                 reject(err);
               } else {
                 resolve();
               }
             });
-            dbUser.save();
-          });
-        })
+            user.save();
+          })
       )
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: witness._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(true);
-              expect(resp._id).to.eql(witness._id.toString());
-              expect(resp._source).to.eql({
-                name: 'John',
-                age: 35,
-                city: { name: 'Paris' },
-                job: { name: 'developer' },
-                skill: { name: 'math' },
-              });
-              resolve();
-            }
-          );
-        })
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: user._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(true);
+                expect(resp._id).to.eql(user._id.toString());
+                expect(resp._source).to.eql({
+                  name: 'John',
+                  age: 35,
+                  city: { name: 'Paris' },
+                  job: { name: 'developer' },
+                  skill: { name: 'math' },
+                });
+                resolve();
+              }
+            );
+          })
       )
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: user._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(true);
-              expect(resp._id).to.eql(user._id.toString());
-              expect(resp._source).to.eql({
-                name: 'John',
-                age: 36,
-                skill: { name: 'math' },
+        () =>
+          new utils.Promise((resolve, reject) => {
+            UserModel.findById(user._id, '+city +job +skill').then(dbUser => {
+              expect(dbUser.city).not.to.be.undefined; // because of select false
+              dbUser.city = undefined; // remove some fields
+              dbUser.job = undefined;
+              dbUser.age = 36;
+
+              dbUser.on('es-indexed', err => {
+                if (err) {
+                  reject(err);
+                } else {
+                  resolve();
+                }
               });
-              resolve();
-            }
-          );
-        })
+              dbUser.save();
+            });
+          })
+      )
+      .then(
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: witness._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(true);
+                expect(resp._id).to.eql(witness._id.toString());
+                expect(resp._source).to.eql({
+                  name: 'John',
+                  age: 35,
+                  city: { name: 'Paris' },
+                  job: { name: 'developer' },
+                  skill: { name: 'math' },
+                });
+                resolve();
+              }
+            );
+          })
+      )
+      .then(
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: user._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(true);
+                expect(resp._id).to.eql(user._id.toString());
+                expect(resp._source).to.eql({
+                  name: 'John',
+                  age: 36,
+                  skill: { name: 'math' },
+                });
+                resolve();
+              }
+            );
+          })
       );
   });
 
@@ -606,16 +618,17 @@ describe('document-hook', () => {
         });
       })
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          witness.on('es-indexed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          witness.save();
-        })
+        () =>
+          new utils.Promise((resolve, reject) => {
+            witness.on('es-indexed', err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+            witness.save();
+          })
       )
       .then(() => {
         UserModel = mongoose.model('User', UserSchema);
@@ -628,110 +641,115 @@ describe('document-hook', () => {
         });
       })
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          user.on('es-indexed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          user.save();
-        })
-      )
-      .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: user._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(true);
-              expect(resp._id).to.eql(user._id.toString());
-              expect(resp._source).to.eql({
-                name: 'John',
-                age: 35,
-                city: { name: 'Paris' },
-                job: { name: 'developer' },
-                skill: { name: 'math' },
-              });
-              resolve();
-            }
-          );
-        })
-      )
-      .then(
-        () => new utils.Promise((resolve, reject) => {
-          UserModel.findById(user._id, '+city +job +skill').then(dbUser => {
-            expect(dbUser.city).not.to.be.undefined; // because of select false
-            dbUser.city = undefined; // remove some fields
-            dbUser.job = undefined;
-            dbUser.age = 36;
-
-            dbUser.on('es-indexed', err => {
+        () =>
+          new utils.Promise((resolve, reject) => {
+            user.on('es-indexed', err => {
               if (err) {
                 reject(err);
               } else {
                 resolve();
               }
             });
-            dbUser.save();
-          });
-        })
+            user.save();
+          })
       )
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: witness._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(true);
-              expect(resp._id).to.eql(witness._id.toString());
-              expect(resp._source).to.eql({
-                name: 'John',
-                age: 35,
-                city: { name: 'Paris' },
-                job: { name: 'developer' },
-                skill: { name: 'math' },
-              });
-              resolve();
-            }
-          );
-        })
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: user._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(true);
+                expect(resp._id).to.eql(user._id.toString());
+                expect(resp._source).to.eql({
+                  name: 'John',
+                  age: 35,
+                  city: { name: 'Paris' },
+                  job: { name: 'developer' },
+                  skill: { name: 'math' },
+                });
+                resolve();
+              }
+            );
+          })
       )
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: user._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(true);
-              expect(resp._id).to.eql(user._id.toString());
-              expect(resp._source).to.eql({
-                name: 'John',
-                age: 36,
-                skill: { name: 'math' },
-                city: null,
-                job: null,
+        () =>
+          new utils.Promise((resolve, reject) => {
+            UserModel.findById(user._id, '+city +job +skill').then(dbUser => {
+              expect(dbUser.city).not.to.be.undefined; // because of select false
+              dbUser.city = undefined; // remove some fields
+              dbUser.job = undefined;
+              dbUser.age = 36;
+
+              dbUser.on('es-indexed', err => {
+                if (err) {
+                  reject(err);
+                } else {
+                  resolve();
+                }
               });
-              resolve();
-            }
-          );
-        })
+              dbUser.save();
+            });
+          })
+      )
+      .then(
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: witness._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(true);
+                expect(resp._id).to.eql(witness._id.toString());
+                expect(resp._source).to.eql({
+                  name: 'John',
+                  age: 35,
+                  city: { name: 'Paris' },
+                  job: { name: 'developer' },
+                  skill: { name: 'math' },
+                });
+                resolve();
+              }
+            );
+          })
+      )
+      .then(
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: user._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(true);
+                expect(resp._id).to.eql(user._id.toString());
+                expect(resp._source).to.eql({
+                  name: 'John',
+                  age: 36,
+                  skill: { name: 'math' },
+                  city: null,
+                  job: null,
+                });
+                resolve();
+              }
+            );
+          })
       );
   });
 
@@ -774,44 +792,46 @@ describe('document-hook', () => {
         UserModel = mongoose.model('User', UserSchema);
       })
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          UserModel.on('es-indexed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          UserModel.findOneAndUpdate(
-            { _id: user._id },
-            { $set: { age: 67 } },
-            { new: true },
-            (err, usr) => {
-              if (err || !usr) {
-                reject(err || new Error('no match'));
+        () =>
+          new utils.Promise((resolve, reject) => {
+            UserModel.on('es-indexed', err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
               }
-            }
-          );
-        })
+            });
+            UserModel.findOneAndUpdate(
+              { _id: user._id },
+              { $set: { age: 67 } },
+              { new: true },
+              (err, usr) => {
+                if (err || !usr) {
+                  reject(err || new Error('no match'));
+                }
+              }
+            );
+          })
       )
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.get(
-            {
-              index: options.index,
-              type: options.type,
-              id: user._id.toString(),
-            },
-            (err, resp) => {
-              expect(resp.found).to.eql(true);
-              expect(resp._id).to.eql(user._id.toString());
-              expect(resp._source).to.eql({ name: 'John', age: 67 });
-              resolve();
-            }
-          );
-        })
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.get(
+              {
+                index: options.index,
+                type: options.type,
+                id: user._id.toString(),
+              },
+              (err, resp) => {
+                expect(resp.found).to.eql(true);
+                expect(resp._id).to.eql(user._id.toString());
+                expect(resp._source).to.eql({ name: 'John', age: 67 });
+                resolve();
+              }
+            );
+          })
       );
   });
 
@@ -837,55 +857,58 @@ describe('document-hook', () => {
       .then(() => henry.save())
       .then(() => UserModel.esRefresh())
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.search(
-            {
-              index: options.index,
-              type: options.type,
-              body: { query: { match_all: {} } },
-            },
-            (err, resp) => {
-              expect(resp.hits.total).to.eql(0);
-              resolve();
-            }
-          );
-        })
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.search(
+              {
+                index: options.index,
+                type: options.type,
+                body: { query: { match_all: {} } },
+              },
+              (err, resp) => {
+                expect(resp.hits.total).to.eql(0);
+                resolve();
+              }
+            );
+          })
       )
       .then(
-        () => new utils.Promise((resolve, reject) => {
-          henry.age = 35;
-          henry.on('es-indexed', err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
-          henry.save();
-        })
+        () =>
+          new utils.Promise((resolve, reject) => {
+            henry.age = 35;
+            henry.on('es-indexed', err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+            henry.save();
+          })
       )
       .then(() => UserModel.esRefresh())
       .then(
-        () => new utils.Promise(resolve => {
-          const options = UserModel.esOptions();
-          const client = options.client;
-          client.search(
-            {
-              index: options.index,
-              type: options.type,
-              body: { query: { match_all: {} } },
-            },
-            (err, resp) => {
-              expect(resp.hits.total).to.eql(1);
-              const hit = resp.hits.hits[0];
-              expect(hit._id).to.eql(henry._id.toString());
-              expect(hit._source).to.eql({ name: 'Henry', age: 35 });
-              resolve();
-            }
-          );
-        })
+        () =>
+          new utils.Promise(resolve => {
+            const options = UserModel.esOptions();
+            const client = options.client;
+            client.search(
+              {
+                index: options.index,
+                type: options.type,
+                body: { query: { match_all: {} } },
+              },
+              (err, resp) => {
+                expect(resp.hits.total).to.eql(1);
+                const hit = resp.hits.hits[0];
+                expect(hit._id).to.eql(henry._id.toString());
+                expect(hit._source).to.eql({ name: 'Henry', age: 35 });
+                resolve();
+              }
+            );
+          })
       );
   });
 });

--- a/test/es5/esCount.js
+++ b/test/es5/esCount.js
@@ -81,14 +81,13 @@ describe('esCount', () => {
 
   it('should handle a full query', () => {
     return UserModel.esCount({
-        bool: {
-          must: { match_all: {} },
-          filter: { range: { age: { lt: 35 } } },
-        },
-      })
-      .then(result => {
-        expect(result.count).to.eql(1);
-      });
+      bool: {
+        must: { match_all: {} },
+        filter: { range: { age: { lt: 35 } } },
+      },
+    }).then(result => {
+      expect(result.count).to.eql(1);
+    });
   });
 
   it('should handle a short query', () => {

--- a/test/es5/esSearch.js
+++ b/test/es5/esSearch.js
@@ -105,17 +105,16 @@ describe('esSearch', () => {
 
   it('should handle a full query', () => {
     return UserModel.esSearch({
-        bool: {
-          must: { match_all: {} },
-          filter: { range: { age: { lt: 35 } } },
-        },
-      })
-      .then(result => {
-        expect(result.hits.total).to.eql(1);
-        const hit = result.hits.hits[0];
-        expect(hit._id).to.eql(jane._id.toString());
-        expect(hit._source).to.eql({ name: 'Jane', age: 34 });
-      });
+      bool: {
+        must: { match_all: {} },
+        filter: { range: { age: { lt: 35 } } },
+      },
+    }).then(result => {
+      expect(result.hits.total).to.eql(1);
+      const hit = result.hits.hits[0];
+      expect(hit._id).to.eql(jane._id.toString());
+      expect(hit._source).to.eql({ name: 'Jane', age: 34 });
+    });
   });
 
   it('should handle a short query', () => {

--- a/test/es5/esSynchronise.js
+++ b/test/es5/esSynchronise.js
@@ -260,7 +260,7 @@ describe('esSynchronise', () => {
           docSent++;
         });
 
-        return UserPluginModel.esSynchronize({}, '+age').then(() => {
+        return UserPluginModel.esSynchronize({}, { name: 1 }).then(() => {
           expect(error).to.be.equal(0);
           expect(docSent).to.be.equal(users.length);
           expect(sent).to.be.equal(Math.ceil(2 * users.length / bulkSize));
@@ -276,7 +276,7 @@ describe('esSynchronise', () => {
                   expect(result.hits.total).to.eql(1);
                   const hit = result.hits.hits[0];
                   expect(hit._source.name).to.be.equal(user.name);
-                  expect(hit._source.age).to.be.equal(user.age);
+                  expect(hit._source.age).to.be.equal(undefined);
                   resolve();
                 })
                 .catch(err => {
@@ -554,7 +554,7 @@ describe('esSynchronise', () => {
         });
 
         return new utils.Promise((resolve, reject) => {
-          UserPluginModel.esSynchronize({}, '+age', err => {
+          UserPluginModel.esSynchronize({}, 'age', err => {
             if (err) {
               reject(err);
               return;
@@ -574,7 +574,7 @@ describe('esSynchronise', () => {
                 .then(result => {
                   expect(result.hits.total).to.eql(1);
                   const hit = result.hits.hits[0];
-                  expect(hit._source.name).to.be.equal(user.name);
+                  expect(hit._source.name).to.be.equal(undefined);
                   expect(hit._source.age).to.be.equal(user.age);
                   resolve();
                 })

--- a/test/es5/hydratation.js
+++ b/test/es5/hydratation.js
@@ -103,112 +103,109 @@ describe('hydratation', () => {
 
   it('should hydrate', () => {
     return UserModel.esSearch(
-        {
-          query: {
-            bool: {
-              must: { match_all: {} },
-              filter: { range: { age: { gte: 35 } } },
-            },
+      {
+        query: {
+          bool: {
+            must: { match_all: {} },
+            filter: { range: { age: { gte: 35 } } },
           },
-          sort: [{ age: { order: 'desc' } }],
         },
-        { hydrate: true }
-      )
-      .then(result => {
-        let hit;
-        expect(result.hits.total).to.eql(2);
+        sort: [{ age: { order: 'desc' } }],
+      },
+      { hydrate: true }
+    ).then(result => {
+      let hit;
+      expect(result.hits.total).to.eql(2);
 
-        hit = result.hits.hits[0];
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(bob._id.toString());
-        expect(hit.doc.name).to.eql(bob.name);
-        expect(hit.doc.age).to.eql(bob.age);
+      hit = result.hits.hits[0];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(bob._id.toString());
+      expect(hit.doc.name).to.eql(bob.name);
+      expect(hit.doc.age).to.eql(bob.age);
 
-        hit = result.hits.hits[1];
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(john._id.toString());
-        expect(hit.doc.name).to.eql(john.name);
-        expect(hit.doc.age).to.eql(john.age);
-      });
+      hit = result.hits.hits[1];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(john._id.toString());
+      expect(hit.doc.name).to.eql(john.name);
+      expect(hit.doc.age).to.eql(john.age);
+    });
   });
 
   it('should hydrate returning only models', () => {
     return UserModel.esSearch(
-        {
-          query: {
-            bool: {
-              must: { match_all: {} },
-              filter: { range: { age: { gte: 35 } } },
-            },
+      {
+        query: {
+          bool: {
+            must: { match_all: {} },
+            filter: { range: { age: { gte: 35 } } },
           },
-          sort: [{ age: { order: 'desc' } }],
         },
-        { hydrate: { docsOnly: true } }
-      )
-      .then(users => {
-        let user;
-        expect(users.length).to.eql(2);
+        sort: [{ age: { order: 'desc' } }],
+      },
+      { hydrate: { docsOnly: true } }
+    ).then(users => {
+      let user;
+      expect(users.length).to.eql(2);
 
-        user = users[0];
-        expect(user._id.toString()).to.eql(bob._id.toString());
-        expect(user.name).to.eql(bob.name);
-        expect(user.age).to.eql(bob.age);
+      user = users[0];
+      expect(user._id.toString()).to.eql(bob._id.toString());
+      expect(user.name).to.eql(bob.name);
+      expect(user.age).to.eql(bob.age);
 
-        user = users[1];
-        expect(user._id.toString()).to.eql(john._id.toString());
-        expect(user.name).to.eql(john.name);
-        expect(user.age).to.eql(john.age);
-      });
+      user = users[1];
+      expect(user._id.toString()).to.eql(john._id.toString());
+      expect(user.name).to.eql(john.name);
+      expect(user.age).to.eql(john.age);
+    });
   });
 
   it('should return an empty array when hydrating only models on 0 hit', () => {
     return UserModel.esSearch(
-        {
-          query: {
-            bool: {
-              must: { match_all: {} },
-              filter: { range: { age: { gte: 100 } } },
-            },
+      {
+        query: {
+          bool: {
+            must: { match_all: {} },
+            filter: { range: { age: { gte: 100 } } },
           },
-          sort: [{ age: { order: 'desc' } }],
         },
-        { hydrate: { docsOnly: true } }
-      )
-      .then(users => {
-        expect(users).to.eql([]);
-      });
+        sort: [{ age: { order: 'desc' } }],
+      },
+      { hydrate: { docsOnly: true } }
+    ).then(users => {
+      expect(users).to.eql([]);
+    });
   });
 
   it('should hydrate using projection', () => {
-    return UserModel.esSearch('name:jane', { hydrate: { select: 'name' } })
-      .then(result => {
-        expect(result.hits.total).to.eql(1);
+    return UserModel.esSearch('name:jane', {
+      hydrate: { select: 'name' },
+    }).then(result => {
+      expect(result.hits.total).to.eql(1);
 
-        const hit = result.hits.hits[0];
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(jane._id.toString());
-        expect(hit.doc.name).to.eql(jane.name);
-        expect(hit.doc.age).to.be.undefined;
-      });
+      const hit = result.hits.hits[0];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(jane._id.toString());
+      expect(hit.doc.name).to.eql(jane.name);
+      expect(hit.doc.age).to.be.undefined;
+    });
   });
 
   it('should hydrate using options', () => {
     return UserModel.esSearch('name:jane', {
-        hydrate: { options: { lean: true } },
-      })
-      .then(result => {
-        expect(result.hits.total).to.eql(1);
+      hydrate: { options: { lean: true } },
+    }).then(result => {
+      expect(result.hits.total).to.eql(1);
 
-        const hit = result.hits.hits[0];
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).not.to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(jane._id.toString());
-        expect(hit.doc.name).to.eql(jane.name);
-        expect(hit.doc.age).to.eql(jane.age);
-      });
+      const hit = result.hits.hits[0];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).not.to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(jane._id.toString());
+      expect(hit.doc.name).to.eql(jane.name);
+      expect(hit.doc.age).to.eql(jane.age);
+    });
   });
 
   it('should hydrate when defined in plugin', () => {
@@ -248,28 +245,27 @@ describe('hydratation', () => {
     const UserModelHydrate = mongoose.model('User', UserSchema);
 
     return UserModelHydrate.esSearch({
-        query: {
-          bool: {
-            must: { match_all: {} },
-            filter: { range: { age: { gte: 35 } } },
-          },
+      query: {
+        bool: {
+          must: { match_all: {} },
+          filter: { range: { age: { gte: 35 } } },
         },
-        sort: [{ age: { order: 'desc' } }],
-      })
-      .then(users => {
-        let user;
-        expect(users.length).to.eql(2);
+      },
+      sort: [{ age: { order: 'desc' } }],
+    }).then(users => {
+      let user;
+      expect(users.length).to.eql(2);
 
-        user = users[0];
-        expect(user._id.toString()).to.eql(bob._id.toString());
-        expect(user.name).to.eql(bob.name);
-        expect(user.age).to.eql(bob.age);
+      user = users[0];
+      expect(user._id.toString()).to.eql(bob._id.toString());
+      expect(user.name).to.eql(bob.name);
+      expect(user.age).to.eql(bob.age);
 
-        user = users[1];
-        expect(user._id.toString()).to.eql(john._id.toString());
-        expect(user.name).to.eql(john.name);
-        expect(user.age).to.eql(john.age);
-      });
+      user = users[1];
+      expect(user._id.toString()).to.eql(john._id.toString());
+      expect(user.name).to.eql(john.name);
+      expect(user.age).to.eql(john.age);
+    });
   });
 
   it('should hydrate when defined in plugin using projection', () => {
@@ -375,119 +371,114 @@ describe('hydratation', () => {
 
   it('should hydrate with a simple populate', () => {
     return UserModel.esSearch(
-        {
-          query: {
-            bool: {
-              must: { match_all: {} },
-              filter: { range: { age: { gte: 35 } } },
-            },
+      {
+        query: {
+          bool: {
+            must: { match_all: {} },
+            filter: { range: { age: { gte: 35 } } },
           },
-          sort: [{ age: { order: 'desc' } }],
         },
-        {
-          hydrate: {
-            populate: {
-              path: 'city',
-            },
+        sort: [{ age: { order: 'desc' } }],
+      },
+      {
+        hydrate: {
+          populate: {
+            path: 'city',
           },
-        }
-      )
-      .then(result => {
-        let hit;
-        expect(result.hits.total).to.eql(2);
+        },
+      }
+    ).then(result => {
+      let hit;
+      expect(result.hits.total).to.eql(2);
 
-        hit = result.hits.hits[0];
+      hit = result.hits.hits[0];
 
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(bob._id.toString());
-        expect(hit.doc.name).to.eql(bob.name);
-        expect(hit.doc.age).to.eql(bob.age);
-        expect(hit.doc.city._id.toString()).to.eql(city2._id.toString());
-        expect(hit.doc.city.name).to.eql(city2.name);
-        // book should not be populated
-        expect(hit.doc.books.length).to.eql(1);
-        expect(hit.doc.books[0].toJSON()).to.eql(book2._id.toString());
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(bob._id.toString());
+      expect(hit.doc.name).to.eql(bob.name);
+      expect(hit.doc.age).to.eql(bob.age);
+      expect(hit.doc.city._id.toString()).to.eql(city2._id.toString());
+      expect(hit.doc.city.name).to.eql(city2.name);
+      // book should not be populated
+      expect(hit.doc.books.length).to.eql(1);
+      expect(hit.doc.books[0].toJSON()).to.eql(book2._id.toString());
 
-        hit = result.hits.hits[1];
-        expect(hit._source).to.be.undefined;
-        expect(hit.doc).to.be.an.instanceof(UserModel);
-        expect(hit.doc._id.toString()).to.eql(john._id.toString());
-        expect(hit.doc.name).to.eql(john.name);
-        expect(hit.doc.age).to.eql(john.age);
-        expect(hit.doc.city._id.toString()).to.eql(city1._id.toString());
-        expect(hit.doc.city.name).to.eql(city1.name);
-        // book should not be populated
-        expect(hit.doc.books.length).to.eql(2);
-        expect(hit.doc.books[0].toJSON()).to.eql(book1._id.toString());
-        expect(hit.doc.books[1].toJSON()).to.eql(book2._id.toString());
-      });
+      hit = result.hits.hits[1];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(john._id.toString());
+      expect(hit.doc.name).to.eql(john.name);
+      expect(hit.doc.age).to.eql(john.age);
+      expect(hit.doc.city._id.toString()).to.eql(city1._id.toString());
+      expect(hit.doc.city.name).to.eql(city1.name);
+      // book should not be populated
+      expect(hit.doc.books.length).to.eql(2);
+      expect(hit.doc.books[0].toJSON()).to.eql(book1._id.toString());
+      expect(hit.doc.books[1].toJSON()).to.eql(book2._id.toString());
+    });
   });
 
-  it(
-    'should hydrate with an array of population including a complex one',
-    () => {
-      return UserModel.esSearch(
-          {
-            query: {
-              bool: {
-                must: { match_all: {} },
-                filter: { range: { age: { gte: 35 } } },
+  it('should hydrate with an array of population including a complex one', () => {
+    return UserModel.esSearch(
+      {
+        query: {
+          bool: {
+            must: { match_all: {} },
+            filter: { range: { age: { gte: 35 } } },
+          },
+        },
+        sort: [{ age: { order: 'desc' } }],
+      },
+      {
+        hydrate: {
+          populate: [
+            {
+              path: 'city',
+            },
+            {
+              path: 'books',
+              populate: {
+                path: 'author',
               },
             },
-            sort: [{ age: { order: 'desc' } }],
-          },
-          {
-            hydrate: {
-              populate: [
-                {
-                  path: 'city',
-                },
-                {
-                  path: 'books',
-                  populate: {
-                    path: 'author',
-                  },
-                },
-              ],
-            },
-          }
-        )
-        .then(result => {
-          let hit;
-          expect(result.hits.total).to.eql(2);
+          ],
+        },
+      }
+    ).then(result => {
+      let hit;
+      expect(result.hits.total).to.eql(2);
 
-          hit = result.hits.hits[0];
+      hit = result.hits.hits[0];
 
-          expect(hit._source).to.be.undefined;
-          expect(hit.doc).to.be.an.instanceof(UserModel);
-          expect(hit.doc._id.toString()).to.eql(bob._id.toString());
-          expect(hit.doc.name).to.eql(bob.name);
-          expect(hit.doc.age).to.eql(bob.age);
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(bob._id.toString());
+      expect(hit.doc.name).to.eql(bob.name);
+      expect(hit.doc.age).to.eql(bob.age);
 
-          expect(hit.doc.city._id.toString()).to.eql(city2._id.toString());
-          expect(hit.doc.city.name).to.eql(city2.name);
+      expect(hit.doc.city._id.toString()).to.eql(city2._id.toString());
+      expect(hit.doc.city.name).to.eql(city2.name);
 
-          expect(hit.doc.books.length).to.eql(1);
-          expect(hit.doc.books[0].toJSON()).to.eql(book2.toJSON());
-          expect(hit.doc.books[0].author.toJSON()).to.eql(author2.toJSON());
+      expect(hit.doc.books.length).to.eql(1);
+      expect(hit.doc.books[0].toJSON()).to.eql(book2.toJSON());
+      expect(hit.doc.books[0].author.toJSON()).to.eql(author2.toJSON());
 
-          hit = result.hits.hits[1];
-          expect(hit._source).to.be.undefined;
-          expect(hit.doc).to.be.an.instanceof(UserModel);
-          expect(hit.doc._id.toString()).to.eql(john._id.toString());
-          expect(hit.doc.name).to.eql(john.name);
-          expect(hit.doc.age).to.eql(john.age);
+      hit = result.hits.hits[1];
+      expect(hit._source).to.be.undefined;
+      expect(hit.doc).to.be.an.instanceof(UserModel);
+      expect(hit.doc._id.toString()).to.eql(john._id.toString());
+      expect(hit.doc.name).to.eql(john.name);
+      expect(hit.doc.age).to.eql(john.age);
 
-          expect(hit.doc.city._id.toString()).to.eql(city1._id.toString());
-          expect(hit.doc.city.name).to.eql(city1.name);
+      expect(hit.doc.city._id.toString()).to.eql(city1._id.toString());
+      expect(hit.doc.city.name).to.eql(city1.name);
 
-          expect(hit.doc.books.length).to.eql(2);
-          expect(hit.doc.books[0].toJSON()).to.eql(book1.toJSON());
-          expect(hit.doc.books[0].author.toJSON()).to.eql(author1.toJSON());
-          expect(hit.doc.books[1].toJSON()).to.eql(book2.toJSON());
-          expect(hit.doc.books[1].author.toJSON()).to.eql(author2.toJSON());
-        });
-    }
-  );
+      expect(hit.doc.books.length).to.eql(2);
+      expect(hit.doc.books[0].toJSON()).to.eql(book1.toJSON());
+      expect(hit.doc.books[0].author.toJSON()).to.eql(author1.toJSON());
+      expect(hit.doc.books[1].toJSON()).to.eql(book2.toJSON());
+      expect(hit.doc.books[1].author.toJSON()).to.eql(author2.toJSON());
+    });
+  });
 });

--- a/test/es5/idsOnly.js
+++ b/test/es5/idsOnly.js
@@ -47,43 +47,41 @@ describe('idsOnly', () => {
 
   it('should return ids', () => {
     return UserModel.esSearch(
-        {
-          query: {
-            bool: {
-              must: { match_all: {} },
-              filter: { range: { age: { gte: 35 } } },
-            },
+      {
+        query: {
+          bool: {
+            must: { match_all: {} },
+            filter: { range: { age: { gte: 35 } } },
           },
-          sort: [{ age: { order: 'desc' } }],
         },
-        { idsOnly: true }
-      )
-      .then(ids => {
-        expect(ids.length).to.eql(2);
-        const idstrings = ids.map(id => {
-          expect(id).to.be.an.instanceof(mongoose.Types.ObjectId);
-          return id.toString();
-        });
-        expect(idstrings).to.eql([bob._id.toString(), john._id.toString()]);
+        sort: [{ age: { order: 'desc' } }],
+      },
+      { idsOnly: true }
+    ).then(ids => {
+      expect(ids.length).to.eql(2);
+      const idstrings = ids.map(id => {
+        expect(id).to.be.an.instanceof(mongoose.Types.ObjectId);
+        return id.toString();
       });
+      expect(idstrings).to.eql([bob._id.toString(), john._id.toString()]);
+    });
   });
 
   it('should an empty array', () => {
     return UserModel.esSearch(
-        {
-          query: {
-            bool: {
-              must: { match_all: {} },
-              filter: { range: { age: { gte: 100 } } },
-            },
+      {
+        query: {
+          bool: {
+            must: { match_all: {} },
+            filter: { range: { age: { gte: 100 } } },
           },
-          sort: [{ age: { order: 'desc' } }],
         },
-        { idsOnly: true }
-      )
-      .then(ids => {
-        expect(ids).to.eql([]);
-      });
+        sort: [{ age: { order: 'desc' } }],
+      },
+      { idsOnly: true }
+    ).then(ids => {
+      expect(ids).to.eql([]);
+    });
   });
 
   it('should return ids when defined in plugin', () => {
@@ -99,22 +97,21 @@ describe('idsOnly', () => {
     const UserModelIdsOnly = mongoose.model('User', UserSchema);
 
     return UserModelIdsOnly.esSearch({
-        query: {
-          bool: {
-            must: { match_all: {} },
-            filter: { range: { age: { gte: 35 } } },
-          },
+      query: {
+        bool: {
+          must: { match_all: {} },
+          filter: { range: { age: { gte: 35 } } },
         },
-        sort: [{ age: { order: 'desc' } }],
-      })
-      .then(ids => {
-        expect(ids.length).to.eql(2);
-        const idstrings = ids.map(id => {
-          expect(id).to.be.an.instanceof(mongoose.Types.ObjectId);
-          return id.toString();
-        });
-        expect(idstrings).to.eql([bob._id.toString(), john._id.toString()]);
+      },
+      sort: [{ age: { order: 'desc' } }],
+    }).then(ids => {
+      expect(ids.length).to.eql(2);
+      const idstrings = ids.map(id => {
+        expect(id).to.be.an.instanceof(mongoose.Types.ObjectId);
+        return id.toString();
       });
+      expect(idstrings).to.eql([bob._id.toString(), john._id.toString()]);
+    });
   });
 
   it('should overwrite defined in plugin value', () => {
@@ -130,26 +127,25 @@ describe('idsOnly', () => {
     const UserModelIdsOnly = mongoose.model('User', UserSchema);
 
     return UserModelIdsOnly.esSearch(
-        {
-          query: {
-            bool: {
-              must: { match_all: {} },
-              filter: { range: { age: { gte: 35 } } },
-            },
+      {
+        query: {
+          bool: {
+            must: { match_all: {} },
+            filter: { range: { age: { gte: 35 } } },
           },
-          sort: [{ age: { order: 'desc' } }],
         },
-        { idsOnly: false }
-      )
-      .then(result => {
-        expect(result.hits.total).to.eql(2);
-        let hit = result.hits.hits[0];
-        expect(hit._id).to.eql(bob._id.toString());
-        expect(hit._source).to.eql({ name: 'Bob', age: 36 });
+        sort: [{ age: { order: 'desc' } }],
+      },
+      { idsOnly: false }
+    ).then(result => {
+      expect(result.hits.total).to.eql(2);
+      let hit = result.hits.hits[0];
+      expect(hit._id).to.eql(bob._id.toString());
+      expect(hit._source).to.eql({ name: 'Bob', age: 36 });
 
-        hit = result.hits.hits[1];
-        expect(hit._id).to.eql(john._id.toString());
-        expect(hit._source).to.eql({ name: 'John', age: 35 });
-      });
+      hit = result.hits.hits[1];
+      expect(hit._id).to.eql(john._id.toString());
+      expect(hit._source).to.eql({ name: 'John', age: 35 });
+    });
   });
 });

--- a/test/es5/model-mapping.js
+++ b/test/es5/model-mapping.js
@@ -439,56 +439,54 @@ describe('model-mapping', () => {
       })
       .then(() => {
         return GroupModel.esSearch({
-            query: {
-              nested: {
-                path: 'user',
-                query: {
-                  bool: {
-                    must: [
-                      { match: { 'user.first': 'Alice' } },
-                      { match: { 'user.last': 'Smith' } },
-                    ],
-                  },
+          query: {
+            nested: {
+              path: 'user',
+              query: {
+                bool: {
+                  must: [
+                    { match: { 'user.first': 'Alice' } },
+                    { match: { 'user.last': 'Smith' } },
+                  ],
                 },
               },
             },
-          })
-          .then(result => {
-            expect(result.hits.total).to.eql(0);
-          });
+          },
+        }).then(result => {
+          expect(result.hits.total).to.eql(0);
+        });
       })
       .then(() => {
         return GroupModel.esSearch({
-            query: {
-              nested: {
-                path: 'user',
-                query: {
-                  bool: {
-                    must: [
-                      { match: { 'user.first': 'Alice' } },
-                      { match: { 'user.last': 'White' } },
-                    ],
-                  },
+          query: {
+            nested: {
+              path: 'user',
+              query: {
+                bool: {
+                  must: [
+                    { match: { 'user.first': 'Alice' } },
+                    { match: { 'user.last': 'White' } },
+                  ],
                 },
               },
             },
-          })
-          .then(result => {
-            expect(result.hits.total).to.eql(1);
-            expect(result.hits.hits[0]._source).to.eql({
-              group: 'fans',
-              user: [
-                {
-                  first: 'John',
-                  last: 'Smith',
-                },
-                {
-                  first: 'Alice',
-                  last: 'White',
-                },
-              ],
-            });
+          },
+        }).then(result => {
+          expect(result.hits.total).to.eql(1);
+          expect(result.hits.hits[0]._source).to.eql({
+            group: 'fans',
+            user: [
+              {
+                first: 'John',
+                last: 'Smith',
+              },
+              {
+                first: 'Alice',
+                last: 'White',
+              },
+            ],
           });
+        });
       });
   });
 
@@ -591,7 +589,8 @@ describe('model-mapping', () => {
           properties.company.properties.city.properties.tags.properties
         ).to.have.all.keys('value');
         expect(
-          properties.company.properties.city.properties.tags.properties.value.type
+          properties.company.properties.city.properties.tags.properties.value
+            .type
         ).to.be.equal('text');
       })
       .then(() => {

--- a/test/es5/promise.js
+++ b/test/es5/promise.js
@@ -1,15 +1,14 @@
 'use strict';
 
-const bluebird = require('bluebird');
 const utils = require('../utils');
 const mongoose = require('mongoose');
 
 const plugin = require('../../');
 
-describe('promise-bluebird', () => {
+describe('promise', () => {
   utils.setup();
 
-  it('should return bluebird promise', () => {
+  it('should return promise', () => {
     const UserSchema = new mongoose.Schema({
       name: String,
     });
@@ -18,6 +17,6 @@ describe('promise-bluebird', () => {
 
     const UserModel = mongoose.model('User', UserSchema);
     const promise = UserModel.esCreateMapping();
-    expect(promise).to.be.an.instanceof(bluebird);
+    expect(promise).to.be.an.instanceof(Promise);
   });
 });

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,9 +1,8 @@
 'use strict';
 
-const _Promise = require('bluebird');
 const mongoose = require('mongoose');
 
-mongoose.Promise = _Promise;
+mongoose.Promise = Promise;
 
 function array(mixed) {
   return Array.isArray(mixed) ? mixed : [mixed];
@@ -33,21 +32,19 @@ function setup() {
 }
 
 function deleteModelIndexes(models) {
-  return _Promise
-    .all(
-      array(models).map(model => {
-        return new _Promise(resolve => {
-          const options = model.esOptions();
-          const client = options.client;
-          client.indices.delete({ index: options.index }, () => {
-            resolve();
-          });
+  return Promise.all(
+    array(models).map(model => {
+      return new Promise(resolve => {
+        const options = model.esOptions();
+        const client = options.client;
+        client.indices.delete({ index: options.index }, () => {
+          resolve();
         });
-      })
-    )
-    .then(() => {
-      // do nothing, just remove the results to allows to use .then(done)
-    });
+      });
+    })
+  ).then(() => {
+    // do nothing, just remove the results to allows to use .then(done)
+  });
 }
 
 function deleteMongooseModels() {
@@ -58,7 +55,7 @@ function deleteMongooseModels() {
 }
 
 module.exports = {
-  Promise: _Promise,
+  Promise,
   setup,
   deleteModelIndexes,
   deleteMongooseModels,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,24 +12,26 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
-acorn@4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
-
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-ajv-keywords@^1.0.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+acorn@^5.4.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
-ajv@^4.7.0:
-  version "4.11.5"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.5.tgz#b6ee74657b993a01dce44b7944d56f485828d5bd"
+ajv-keywords@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
+
+ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
     co "^4.6.0"
-    json-stable-stringify "^1.0.1"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -43,23 +45,27 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+ansi-escapes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
+ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
-    color-convert "^1.0.0"
+    color-convert "^1.9.0"
 
 argparse@^1.0.7:
   version "1.0.9"
@@ -93,21 +99,9 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
-
 assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
-
-ast-types@0.8.18:
-  version "0.8.18"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.18.tgz#c8b98574898e8914e9d8de74b947564a9fe929af"
-
-ast-types@0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.4.tgz#410d1f81890aeb8e0a38621558ba5869ae53c91b"
 
 async@1.x, async@^1.4.0:
   version "1.5.2"
@@ -123,29 +117,29 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
 
-aws4@^1.2.1:
+aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@6.22.0, babel-code-frame@^6.16.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
+babel-code-frame@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
-    chalk "^1.1.0"
+    chalk "^1.1.3"
     esutils "^2.0.2"
-    js-tokens "^3.0.0"
-
-babylon@6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
+    js-tokens "^3.0.2"
 
 balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
@@ -157,21 +151,34 @@ bluebird@2.10.2:
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.10.2.tgz#024a5517295308857f14f91f1106fc3b555f446b"
 
-bluebird@^3.4.6:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
+bluebird@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
+boom@4.x.x:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
   dependencies:
-    hoek "2.x.x"
+    hoek "4.x.x"
+
+boom@5.x.x:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
+  dependencies:
+    hoek "4.x.x"
 
 brace-expansion@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
   dependencies:
     balanced-match "^0.4.1"
+    concat-map "0.0.1"
+
+brace-expansion@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  dependencies:
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 browser-stdout@1.3.0:
@@ -186,7 +193,7 @@ buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
-builtin-modules@^1.1.1:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -204,9 +211,9 @@ camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
-caseless@~0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -215,15 +222,18 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
+chai@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
   dependencies:
     assertion-error "^1.0.1"
-    deep-eql "^0.1.3"
-    type-detect "^1.0.0"
+    check-error "^1.0.1"
+    deep-eql "^3.0.0"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
 
-chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -233,15 +243,31 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.0, chalk@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
-cli-cursor@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
-    restore-cursor "^1.0.1"
+    restore-cursor "^2.0.0"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -259,13 +285,9 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
-code-point-at@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-
-color-convert@^1.0.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+color-convert@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
 
@@ -273,27 +295,21 @@ color-name@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.2.tgz#5c8ab72b64bd2215d617ae9559ebb148475cf98d"
 
-colors@>=0.6.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
-
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0, commander@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
+commander@2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6:
+concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -309,27 +325,29 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-coveralls@^2.11.14:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.12.0.tgz#b3d064108e29728385b56e42fc2d119f43e0e517"
+coveralls@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.0.tgz#22ef730330538080d29b8c151dc9146afde88a99"
   dependencies:
-    js-yaml "3.6.1"
-    lcov-parse "0.0.10"
-    log-driver "1.2.5"
-    minimist "1.2.0"
-    request "2.79.0"
+    js-yaml "^3.6.1"
+    lcov-parse "^0.0.10"
+    log-driver "^1.2.5"
+    minimist "^1.2.0"
+    request "^2.79.0"
 
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
-    boom "2.x.x"
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
-d@^0.1.1, d@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
+cryptiles@3.x.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
   dependencies:
-    es5-ext "~0.10.2"
+    boom "5.x.x"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -343,21 +361,27 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@^2.1.1, debug@^2.2.0:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
+debug@3.1.0, debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
-    ms "0.7.2"
+    ms "2.0.0"
+
+debug@^2.6.8, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-eql@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
+deep-eql@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
   dependencies:
-    type-detect "0.1.1"
+    type-detect "^4.0.0"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -379,16 +403,22 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
-diff@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+diff@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
 
-doctrine@1.5.0, doctrine@^1.2.2:
+doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -405,61 +435,15 @@ elasticsearch@^12.1.3:
     lodash "^4.12.0"
     promise "^7.1.1"
 
-es5-ext@^0.10.7, es5-ext@^0.10.8, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.10.7:
-  version "0.10.13"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.13.tgz#a390ab717bde1ce3b4cbaeabe23ca8fbddcb06f6"
+error-ex@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
-    es6-iterator "2"
-    es6-symbol "~3.1"
-
-es6-iterator@2:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.0.tgz#bd968567d61635e33c0b80727613c9cb4b096bac"
-  dependencies:
-    d "^0.1.1"
-    es5-ext "^0.10.7"
-    es6-symbol "3"
-
-es6-map@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.4.tgz#a34b147be224773a4d7da8072794cefa3632b897"
-  dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.11"
-    es6-iterator "2"
-    es6-set "~0.1.3"
-    es6-symbol "~3.1.0"
-    event-emitter "~0.3.4"
+    is-arrayish "^0.2.1"
 
 es6-promise@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.2.1.tgz#ec56233868032909207170c39448e24449dd1fc4"
-
-es6-set@~0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.4.tgz#9516b6761c2964b92ff479456233a247dc707ce8"
-  dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.11"
-    es6-iterator "2"
-    es6-symbol "3"
-    event-emitter "~0.3.4"
-
-es6-symbol@3, es6-symbol@~3.1, es6-symbol@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.0.tgz#94481c655e7a7cad82eba832d97d5433496d7ffa"
-  dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.11"
-
-es6-weak-map@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.1.tgz#0d2bbd8827eb5fb4ba8f97fbfea50d43db21ea81"
-  dependencies:
-    d "^0.1.1"
-    es5-ext "^0.10.8"
-    es6-iterator "2"
-    es6-symbol "3"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -476,114 +460,135 @@ escodegen@1.8.x:
   optionalDependencies:
     source-map "~0.2.0"
 
-escope@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+eslint-config-airbnb-base@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
   dependencies:
-    es6-map "^0.1.3"
-    es6-weak-map "^2.0.1"
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
+    eslint-restricted-globals "^0.1.1"
 
-eslint-config-airbnb-base@^11.1.0:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.1.1.tgz#61e9e89e4eb89f474f6913ac817be9fbb59063e0"
-
-eslint-config-prettier@^1.4.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-1.5.0.tgz#969b6d21b2eb2574a6810426507f755072db1963"
+eslint-config-prettier@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
   dependencies:
     get-stdin "^5.0.1"
 
-eslint-import-resolver-node@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
   dependencies:
-    debug "^2.2.0"
-    object-assign "^4.0.1"
-    resolve "^1.1.6"
+    debug "^2.6.9"
+    resolve "^1.5.0"
 
-eslint-module-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
+eslint-module-utils@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
   dependencies:
-    debug "2.2.0"
+    debug "^2.6.8"
     pkg-dir "^1.0.0"
 
 eslint-plugin-chai-expect@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-1.1.1.tgz#cd640b8b38cf6c3abcc378673b7b173b99ddc70a"
 
-eslint-plugin-import@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"
+eslint-plugin-import@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
   dependencies:
     builtin-modules "^1.1.1"
     contains-path "^0.1.0"
-    debug "^2.2.0"
+    debug "^2.6.8"
     doctrine "1.5.0"
-    eslint-import-resolver-node "^0.2.0"
-    eslint-module-utils "^2.0.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.1.1"
     has "^1.0.1"
     lodash.cond "^4.3.0"
     minimatch "^3.0.3"
-    pkg-up "^1.0.0"
+    read-pkg-up "^2.0.0"
 
-eslint-plugin-prettier@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.0.1.tgz#2ae1216cf053dd728360ca8560bf1aabc8af3fa9"
+eslint-plugin-prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz#33e4e228bdb06142d03c560ce04ec23f6c767dd7"
   dependencies:
-    requireindex "~1.1.0"
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
 
-eslint@^3.16.1:
-  version "3.17.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.17.1.tgz#b80ae12d9c406d858406fccda627afce33ea10ea"
+eslint-restricted-globals@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
+
+eslint-scope@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
-    babel-code-frame "^6.16.0"
-    chalk "^1.1.3"
-    concat-stream "^1.4.6"
-    debug "^2.1.1"
-    doctrine "^1.2.2"
-    escope "^3.6.0"
-    espree "^3.4.0"
-    estraverse "^4.2.0"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^4.17.0:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.17.0.tgz#dc24bb51ede48df629be7031c71d9dc0ee4f3ddf"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.2"
+    esquery "^1.0.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
-    glob "^7.0.3"
-    globals "^9.14.0"
-    ignore "^3.2.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
     imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    is-my-json-valid "^2.10.0"
+    inquirer "^3.0.6"
     is-resolvable "^1.0.0"
-    js-yaml "^3.5.1"
-    json-stable-stringify "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.0.0"
-    mkdirp "^0.5.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.1"
-    pluralize "^1.2.1"
-    progress "^1.1.8"
-    require-uncached "^1.0.2"
-    shelljs "^0.7.5"
-    strip-bom "^3.0.0"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
     strip-json-comments "~2.0.1"
-    table "^3.7.8"
+    table "^4.0.1"
     text-table "~0.2.0"
-    user-home "^2.0.0"
 
-espree@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.0.tgz#41656fa5628e042878025ef467e78f125cb86e1d"
+espree@^3.5.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.3.tgz#931e0af64e7fbbed26b050a29daad1fc64799fa6"
   dependencies:
-    acorn "4.0.4"
+    acorn "^5.4.0"
     acorn-jsx "^3.0.0"
 
 esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
   version "4.1.0"
@@ -596,7 +601,7 @@ estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
-estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -604,39 +609,47 @@ estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
-esutils@2.0.2, esutils@^2.0.2:
+esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-event-emitter@~0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.4.tgz#8d63ddfb4cfe1fae3b32ca265c4c720222080bb5"
+extend@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+
+external-editor@^2.0.4:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
   dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.7"
-
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
-
-extend@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
 
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
+fast-deep-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-diff@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-figures@^1.3.5:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   dependencies:
     escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
 
 file-entry-cache@^2.0.0:
   version "2.0.0"
@@ -652,6 +665,12 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-up@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
+
 flat-cache@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.2.2.tgz#fa86714e72c21db88601761ecf2f555d1abc6b96"
@@ -661,21 +680,13 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-parser@0.38.0:
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.38.0.tgz#a631c46170c5b42400d905a75cfc83ce8db29424"
-  dependencies:
-    ast-types "0.8.18"
-    colors ">=0.6.2"
-    minimist ">=0.2.0"
-
 forever-agent@^0.6.0, forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@~2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.2.tgz#89c3534008b97eada4cbb157d58f6f5df025eae4"
+form-data@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
@@ -689,17 +700,15 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
-generate-function@^2.0.0:
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
+get-func-name@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  dependencies:
-    is-property "^1.0.0"
-
-get-stdin@5.0.1, get-stdin@^5.0.1:
+get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
@@ -709,25 +718,14 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob@7.0.5:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
+glob@7.1.2, glob@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -741,9 +739,20 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.14.0:
-  version "9.16.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.16.0.tgz#63e903658171ec2d9f51b1d31de5e2b8dc01fb80"
+glob@^7.0.3, glob@^7.0.5:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+globals@^11.0.1:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -760,13 +769,9 @@ graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-
-growl@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+growl@1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
 
 handlebars@^4.0.1:
   version "4.0.6"
@@ -778,14 +783,16 @@ handlebars@^4.0.1:
   optionalDependencies:
     uglify-js "^2.6"
 
-har-validator@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+
+har-validator@~5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
   dependencies:
-    chalk "^1.1.1"
-    commander "^2.9.0"
-    is-my-json-valid "^2.12.4"
-    pinkie-promise "^2.0.0"
+    ajv "^5.1.0"
+    har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -797,40 +804,56 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
 has@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
 
-hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
+hawk@~6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
   dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
+    boom "4.x.x"
+    cryptiles "3.x.x"
+    hoek "4.x.x"
+    sntp "2.x.x"
 
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+hoek@4.x.x:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
 hooks-fixed@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/hooks-fixed/-/hooks-fixed-2.0.0.tgz#a01d894d52ac7f6599bbb1f63dfc9c411df70cba"
 
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
+hosted-git-info@^2.1.4:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
   dependencies:
-    assert-plus "^0.2.0"
+    assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-ignore@^3.2.0:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.4.tgz#4055e03596729a8fabe45a43c100ad5ed815c4e8"
+iconv-lite@^0.4.17:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+ignore@^3.3.3:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -847,50 +870,42 @@ inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inquirer@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+inquirer@^3.0.6:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:
-    ansi-escapes "^1.1.0"
-    ansi-regex "^2.0.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    figures "^1.3.5"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
     lodash "^4.3.0"
-    readline2 "^1.0.1"
-    run-async "^0.1.0"
-    rx-lite "^3.1.2"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
 
-interpret@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
 is-buffer@^1.0.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
-is-fullwidth-code-point@^1.0.0:
+is-builtin-module@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
   dependencies:
-    number-is-nan "^1.0.0"
+    builtin-modules "^1.0.0"
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-
-is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
-  dependencies:
-    generate-function "^2.0.0"
-    generate-object-property "^1.1.0"
-    jsonpointer "^4.0.0"
-    xtend "^4.0.0"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -908,9 +923,9 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-property@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
 is-resolvable@^1.0.0:
   version "1.0.0"
@@ -929,6 +944,10 @@ isarray@^1.0.0, isarray@~1.0.0:
 isexe@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz#36f3e22e60750920f5e7241a476a8c6a42275ad0"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -953,21 +972,9 @@ istanbul@^0.4.5:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-jest-matcher-utils@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz#5ecd9b63565d2b001f61fbf7ec4c7f537964564d"
-  dependencies:
-    chalk "^1.1.3"
-    pretty-format "^19.0.0"
-
-jest-validate@19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-19.0.0.tgz#8c6318a20ecfeaba0ba5378bfbb8277abded4173"
-  dependencies:
-    chalk "^1.1.1"
-    jest-matcher-utils "^19.0.0"
-    leven "^2.0.0"
-    pretty-format "^19.0.0"
+jest-docblock@^21.0.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
 jodid25519@^1.0.0:
   version "1.0.2"
@@ -975,46 +982,43 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-js-tokens@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.6.1, js-yaml@3.x, js-yaml@^3.5.1:
+js-yaml@3.x:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
+js-yaml@^3.6.1, js-yaml@^3.9.1:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  dependencies:
-    jsonify "~0.0.0"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-
-json3@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
 jsprim@^1.2.2:
   version "1.4.0"
@@ -1039,13 +1043,9 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
-lcov-parse@0.0.10:
+lcov-parse@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
-
-leven@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -1054,62 +1054,35 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash._baseassign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
   dependencies:
-    lodash._basecopy "^3.0.0"
-    lodash.keys "^3.0.0"
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
 
-lodash._basecopy@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-
-lodash._basecreate@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
-
-lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-
-lodash._isiterateecall@^3.0.0:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash.create@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._basecreate "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
-
-lodash.isarguments@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
-
-lodash.isarray@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.keys@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
-  dependencies:
-    lodash._getnative "^3.0.0"
-    lodash.isarguments "^3.0.0"
-    lodash.isarray "^3.0.0"
-
-lodash@^4.0.0, lodash@^4.12.0, lodash@^4.14.0, lodash@^4.3.0:
+lodash@^4.12.0, lodash@^4.14.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-log-driver@1.2.5:
+lodash@^4.17.4:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+log-driver@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
@@ -1117,15 +1090,36 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
+lru-cache@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 mime-db@~1.26.0:
   version "1.26.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.26.0.tgz#eaffcd0e4fc6935cf8134da246e2e6c35305adff"
 
-mime-types@^2.1.12, mime-types@~2.1.7:
+mime-db@~1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+
+mime-types@^2.1.12:
   version "2.1.14"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee"
   dependencies:
     mime-db "~1.26.0"
+
+mime-types@~2.1.17:
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+  dependencies:
+    mime-db "~1.30.0"
+
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
 "minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
@@ -1133,35 +1127,40 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     brace-expansion "^1.0.0"
 
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@>=0.2.0:
+minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
-mocha@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.2.0.tgz#7dc4f45e5088075171a68896814e6ae9eb7a85e3"
+mocha@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.0.0.tgz#cccac988b0bc5477119cba0e43de7af6d6ad8f4e"
   dependencies:
     browser-stdout "1.3.0"
-    commander "2.9.0"
-    debug "2.2.0"
-    diff "1.4.0"
+    commander "2.11.0"
+    debug "3.1.0"
+    diff "3.3.1"
     escape-string-regexp "1.0.5"
-    glob "7.0.5"
-    growl "1.9.2"
-    json3 "3.3.2"
-    lodash.create "3.1.1"
+    glob "7.1.2"
+    growl "1.10.3"
+    he "1.1.1"
     mkdirp "0.5.1"
-    supports-color "3.1.2"
+    supports-color "4.4.0"
 
 mongodb-core@2.1.8:
   version "2.1.8"
@@ -1220,13 +1219,17 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 muri@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/muri/-/muri-1.2.1.tgz#ec7ea5ce6ca6a523eb1ab35bacda5fa816c9aa3c"
 
-mute-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -1238,15 +1241,20 @@ nopt@3.x:
   dependencies:
     abbrev "1"
 
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+normalize-package-data@^2.3.2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
 
-oauth-sign@~0.8.1:
+oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1256,9 +1264,11 @@ once@1.x, once@^1.3.0:
   dependencies:
     wrappy "1"
 
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -1278,9 +1288,31 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-os-homedir@^1.0.0:
+os-tmpdir@~1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+
+p-limit@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  dependencies:
+    p-try "^1.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  dependencies:
+    error-ex "^1.2.0"
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -1288,13 +1320,35 @@ path-exists@^2.0.0:
   dependencies:
     pinkie-promise "^2.0.0"
 
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
+
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -1316,48 +1370,25 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-pkg-up@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
-  dependencies:
-    find-up "^1.0.0"
-
-pluralize@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-prettier@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-0.19.0.tgz#8b473989a51c76649ea1e2eb7ea3f055cc4b8422"
-  dependencies:
-    ast-types "0.9.4"
-    babel-code-frame "6.22.0"
-    babylon "6.15.0"
-    chalk "1.1.3"
-    esutils "2.0.2"
-    flow-parser "0.38.0"
-    get-stdin "5.0.1"
-    glob "7.1.1"
-    jest-validate "19.0.0"
-    minimist "1.2.0"
-
-pretty-format@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-19.0.0.tgz#56530d32acb98a3fa4851c4e2b9d37b420684c84"
-  dependencies:
-    ansi-styles "^3.0.0"
+prettier@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-progress@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 promise@^7.1.1:
   version "7.1.1"
@@ -1365,13 +1396,32 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-qs@~6.3.0:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+qs@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 readable-stream@2.1.5:
   version "2.1.5"
@@ -1397,20 +1447,6 @@ readable-stream@^2.2.2:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readline2@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    mute-stream "0.0.5"
-
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  dependencies:
-    resolve "^1.1.6"
-
 regexp-clone@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-0.0.1.tgz#a7c2e09891fdbf38fbb10d376fb73003e68ac589"
@@ -1419,32 +1455,34 @@ repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
-request@2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+request@^2.79.0:
+  version "2.83.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
     combined-stream "~1.0.5"
-    extend "~3.0.0"
+    extend "~3.0.1"
     forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    hawk "~6.0.2"
+    http-signature "~1.2.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
     json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
-    uuid "^3.0.0"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    stringstream "~0.0.5"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
 
-require-uncached@^1.0.2:
+require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   dependencies:
@@ -1458,10 +1496,6 @@ require_optional@~1.0.0:
     resolve-from "^2.0.0"
     semver "^5.1.0"
 
-requireindex@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
-
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -1470,16 +1504,22 @@ resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
 
-resolve@1.1.x, resolve@^1.1.6:
+resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+resolve@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
+    path-parse "^1.0.5"
+
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -1493,35 +1533,57 @@ rimraf@^2.2.8:
   dependencies:
     glob "^7.0.5"
 
-run-async@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
-    once "^1.3.0"
+    is-promise "^2.1.0"
 
-rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-shelljs@^0.7.5:
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
   dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shortid@^2.2.8:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.8.tgz#033b117d6a2e975804f6f0969dbe7d3d0b355131"
 
-slice-ansi@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+signal-exit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 sliced@0.0.5:
   version "0.0.5"
@@ -1531,11 +1593,11 @@ sliced@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sliced/-/sliced-1.0.1.tgz#0b3a662b5d04c3177b1926bea82b03f837a2ef41"
 
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
+sntp@2.x.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
   dependencies:
-    hoek "2.x.x"
+    hoek "4.x.x"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -1552,6 +1614,20 @@ source-map@~0.2.0:
 source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+spdx-correct@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+  dependencies:
+    spdx-license-ids "^1.0.2"
+
+spdx-expression-parse@~1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+
+spdx-license-ids@^1.0.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1572,26 +1648,18 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
-
-string-width@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+string-width@^2.1.0, string-width@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^3.0.0"
+    strip-ansi "^4.0.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-stringstream@~0.0.4:
+stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -1601,6 +1669,12 @@ strip-ansi@^3.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
+
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -1609,11 +1683,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-supports-color@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+supports-color@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
-    has-flag "^1.0.0"
+    has-flag "^2.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -1625,16 +1699,22 @@ supports-color@^3.1.0:
   dependencies:
     has-flag "^1.0.0"
 
-table@^3.7.8:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+supports-color@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
-    ajv "^4.7.0"
-    ajv-keywords "^1.0.0"
-    chalk "^1.1.1"
-    lodash "^4.0.0"
-    slice-ansi "0.0.4"
-    string-width "^2.0.0"
+    has-flag "^2.0.0"
+
+table@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+  dependencies:
+    ajv "^5.2.3"
+    ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -1644,9 +1724,15 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-tough-cookie@~2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
+
+tough-cookie@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
 
@@ -1654,9 +1740,11 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
-tunnel-agent@~0.4.1:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
@@ -1668,13 +1756,9 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
-
-type-detect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+type-detect@^4.0.0:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -1692,19 +1776,20 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-user-home@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
-  dependencies:
-    os-homedir "^1.0.0"
-
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^3.0.0:
+uuid@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+validate-npm-package-license@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  dependencies:
+    spdx-correct "~1.0.0"
+    spdx-expression-parse "~1.0.0"
 
 verror@1.3.6:
   version "1.3.6"
@@ -1717,6 +1802,12 @@ which@^1.1.1:
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
   dependencies:
     isexe "^1.1.1"
+
+which@^1.2.9:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -1744,9 +1835,9 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-xtend@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yargs@~3.10.0:
   version "3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,10 +151,6 @@ bluebird@2.10.2:
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.10.2.tgz#024a5517295308857f14f91f1106fc3b555f446b"
 
-bluebird@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-
 boom@4.x.x:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,10 @@ acorn@^5.4.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
+agentkeepalive@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-2.2.0.tgz#c5d1bd4b129008f1163f236f86e5faea2026e2ef"
+
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
@@ -86,10 +90,6 @@ array-uniq@^1.0.1:
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-
-asap@~2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
 
 asn1@~0.2.3:
   version "0.2.3"
@@ -426,14 +426,16 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-elasticsearch@^12.1.3:
-  version "12.1.3"
-  resolved "https://registry.yarnpkg.com/elasticsearch/-/elasticsearch-12.1.3.tgz#5108e67ae5d83e5e7f30d3d294fd7017df0e3771"
+elasticsearch@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/elasticsearch/-/elasticsearch-14.1.0.tgz#9a5e461fa3bacc1bd91411534650c63408121f81"
   dependencies:
+    agentkeepalive "^2.2.0"
     chalk "^1.0.0"
-    forever-agent "^0.6.0"
-    lodash "^4.12.0"
-    promise "^7.1.1"
+    lodash "2.4.2"
+    lodash.get "^4.4.2"
+    lodash.isempty "^4.4.0"
+    lodash.trimend "^4.5.1"
 
 error-ex@^1.2.0:
   version "1.3.1"
@@ -680,7 +682,7 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-forever-agent@^0.6.0, forever-agent@~0.6.1:
+forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
@@ -1074,7 +1076,23 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash@^4.12.0, lodash@^4.14.0, lodash@^4.3.0:
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.isempty@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+
+lodash.trimend@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/lodash.trimend/-/lodash.trimend-4.5.1.tgz#12804437286b98cad8996b79414e11300114082f"
+
+lodash@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
+
+lodash@^4.14.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -1389,12 +1407,6 @@ process-nextick-args@~1.0.6:
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
-
-promise@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
-  dependencies:
-    asap "~2.0.3"
 
 pseudomap@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,9 +147,9 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bluebird@2.10.2:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.10.2.tgz#024a5517295308857f14f91f1106fc3b555f446b"
+bluebird@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
 boom@4.x.x:
   version "4.3.1"
@@ -351,21 +351,15 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+debug@2.6.9, debug@^2.6.8, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
-    ms "0.7.1"
+    ms "2.0.0"
 
 debug@3.1.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  dependencies:
-    ms "2.0.0"
-
-debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -438,10 +432,6 @@ error-ex@^1.2.0:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
-
-es6-promise@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.2.1.tgz#ec56233868032909207170c39448e24449dd1fc4"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -829,10 +819,6 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hooks-fixed@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hooks-fixed/-/hooks-fixed-2.0.0.tgz#a01d894d52ac7f6599bbb1f63dfc9c411df70cba"
-
 hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
@@ -1027,9 +1013,9 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-kareem@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/kareem/-/kareem-1.2.1.tgz#acdb8c8119845834abbfa58ade1cf9dea63dc752"
+kareem@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.0.3.tgz#d05c7ad76b045bc50c197b2cd13d2d1ef5671070"
 
 kind-of@^3.0.2:
   version "3.1.0"
@@ -1072,7 +1058,7 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash.get@^4.4.2:
+lodash.get@4.4.2, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
@@ -1088,13 +1074,13 @@ lodash@2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
 
-lodash@^4.14.0, lodash@^4.3.0:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@^4.17.4:
+lodash@^4.14.0, lodash@^4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lodash@^4.3.0:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 log-driver@^1.2.5:
   version "1.2.5"
@@ -1176,70 +1162,55 @@ mocha@^5.0.0:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
-mongodb-core@2.1.8:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-2.1.8.tgz#b33e0370d0a59d97b6cb1ec610527be9e95ca2c0"
+mongodb-core@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.0.2.tgz#914896092dd45427d9a4f98a7997a0bfb81d163b"
   dependencies:
     bson "~1.0.4"
-    require_optional "~1.0.0"
+    require_optional "^1.0.1"
 
-mongodb@2.2.24:
-  version "2.2.24"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-2.2.24.tgz#80f40d6ec5bdec0ddecf0f9ce0144e794c46449a"
+mongodb@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.0.2.tgz#28172302ed4e9388d8091e2cc4618057e6f5debc"
   dependencies:
-    es6-promise "3.2.1"
-    mongodb-core "2.1.8"
-    readable-stream "2.1.5"
+    mongodb-core "3.0.2"
 
-mongoose@^4.2.2:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-4.9.0.tgz#5465fc3c1d4c9e43b035e9652412dcce3fa4d55c"
+mongoose-legacy-pluralize@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
+
+mongoose@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.0.3.tgz#e320c629fa44e4afba1d8b4ac865f9a4cea7f157"
   dependencies:
     async "2.1.4"
     bson "~1.0.4"
-    hooks-fixed "2.0.0"
-    kareem "1.2.1"
-    mongodb "2.2.24"
-    mpath "0.2.1"
-    mpromise "0.5.5"
-    mquery "2.3.0"
-    ms "0.7.2"
-    muri "1.2.1"
+    kareem "2.0.3"
+    lodash.get "4.4.2"
+    mongodb "3.0.2"
+    mongoose-legacy-pluralize "1.0.2"
+    mpath "0.3.0"
+    mquery "3.0.0"
+    ms "2.0.0"
     regexp-clone "0.0.1"
     sliced "1.0.1"
 
-mpath@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.2.1.tgz#3a4e829359801de96309c27a6b2e102e89f9e96e"
+mpath@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.3.0.tgz#7a58f789e9b5fd3c94520634157960f26bd5ef44"
 
-mpromise@0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/mpromise/-/mpromise-0.5.5.tgz#f5b24259d763acc2257b0a0c8c6d866fd51732e6"
-
-mquery@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/mquery/-/mquery-2.3.0.tgz#3d1717ad8958d0c99e42ea2461a109f3e5f3e458"
+mquery@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.0.0.tgz#e5f387dbabc0b9b69859e550e810faabe0ceabb0"
   dependencies:
-    bluebird "2.10.2"
-    debug "2.2.0"
+    bluebird "3.5.0"
+    debug "2.6.9"
     regexp-clone "0.0.1"
     sliced "0.0.5"
-
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
-
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-
-muri@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/muri/-/muri-1.2.1.tgz#ec7ea5ce6ca6a523eb1ab35bacda5fa816c9aa3c"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -1431,18 +1402,6 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
-  dependencies:
-    buffer-shims "^1.0.0"
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
 readable-stream@^2.2.2:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.5.tgz#a0b187304e05bab01a4ce2b4cc9c607d5aa1d606"
@@ -1497,9 +1456,9 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-require_optional@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.0.tgz#52a86137a849728eb60a55533617f8f914f59abf"
+require_optional@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
   dependencies:
     resolve-from "^2.0.0"
     semver "^5.1.0"
@@ -1561,13 +1520,9 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-
-semver@^5.1.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Update dependencies. 
Make compatible with mongoose 5.0 and elastic 14.0.

So many changes due to updating `prettier` and its warnings in first commit `chore: update deps, fix new prettier warns (only styling code changes)`. 

**Better to make code review by commits**. Only first commit is huge and was made automatically by `eslint --fix`. All other commits are small and made by hands.

PS. All my changes tested with new and old versions of mongoose on both es2 and es5. So it backward compatible for users which not update mongoose/elastic packages.